### PR TITLE
ci: allow Dependabot major Maven updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,7 @@ updates:
         patterns:
           - "*"
         update-types:
+          - "major"
           - "minor"
           - "patch"
 


### PR DESCRIPTION
## Summary
- Allow Dependabot's Maven dependency group to include major updates.
- Keep major, minor, and patch Maven updates flowing through CI instead of pre-filtering them.

## Verification
- `./mvnw.cmd -B -ntp verify`