### PR TITLE
ci: add JaCoCo coverage reporting

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -26,10 +26,18 @@ jobs:
     name: Verify (Java 25)
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: read
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Java 25
         uses: actions/setup-java@v5
@@ -40,11 +48,52 @@ jobs:
 
       - name: Verify
         if: github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
-        run: ./mvnw $MAVEN_ARGS verify
+        run: ./mvnw $MAVEN_ARGS -Pcoverage verify
 
       - name: Verify release profile
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
-        run: ./mvnw $MAVEN_ARGS -Prelease verify
+        run: ./mvnw $MAVEN_ARGS -Pcoverage,release verify
+
+      - name: Upload test and coverage artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-and-coverage-reports
+          path: |
+            target/site/jacoco/
+            target/surefire-reports/
+            target/failsafe-reports/
+          if-no-files-found: ignore
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
+          files: target/site/jacoco/jacoco.xml
+          disable_search: true
+          flags: java
+          name: java-coverage
+          fail_ci_if_error: true
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
+          files: target/surefire-reports/*.xml,target/failsafe-reports/*.xml
+          disable_search: true
+          report_type: test_results
+          flags: java
+          name: java-tests
+          fail_ci_if_error: true
+
+      - name: SonarQube Cloud analysis
+        if: ${{ env.SONAR_TOKEN != '' }}
+        run: ./mvnw $MAVEN_ARGS sonar:sonar
+
+      - name: Skip SonarQube Cloud analysis
+        if: ${{ env.SONAR_TOKEN == '' }}
+        run: echo "SONAR_TOKEN secret is not configured; skipping SonarQube Cloud analysis."
 
   compatibility:
     name: Compatibility (Java ${{ matrix.java }})

--- a/README.md
+++ b/README.md
@@ -441,6 +441,17 @@ Run the complete verification suite:
 
 PostgreSQL integration tests use Testcontainers, so Docker must be available.
 
+Generate JaCoCo coverage for unit and integration tests:
+
+```bash
+./mvnw -Pcoverage verify
+```
+
+The XML report is written to `target/site/jacoco/jacoco.xml`; the HTML report
+is written to `target/site/jacoco/index.html`. CI uploads the JaCoCo report and
+JUnit XML test results to Codecov, and runs SonarQube Cloud analysis when the
+repository has a `SONAR_TOKEN` secret configured.
+
 Verify public Javadocs and release checks:
 
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,13 @@
     <perplexhub.rsql.version>7.0.2</perplexhub.rsql.version>
     <datasource-proxy.version>1.11.0</datasource-proxy.version>
     <expressly.version>6.0.0</expressly.version>
+    <jacoco.version>0.8.15</jacoco.version>
+    <sonar.maven.plugin.version>5.7.0.6970</sonar.maven.plugin.version>
+    <sonar.projectKey>ggomarighetti_search-helper</sonar.projectKey>
+    <sonar.organization>ggomarighetti</sonar.organization>
+    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    <sonar.junit.reportPaths>target/surefire-reports,target/failsafe-reports</sonar.junit.reportPaths>
   </properties>
 
   <dependencyManagement>
@@ -197,10 +204,54 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.sonarsource.scanner.maven</groupId>
+        <artifactId>sonar-maven-plugin</artifactId>
+        <version>${sonar.maven.plugin.version}</version>
+      </plugin>
     </plugins>
   </build>
 
   <profiles>
+    <profile>
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${jacoco.version}</version>
+            <executions>
+              <execution>
+                <id>prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+                <configuration>
+                  <append>true</append>
+                  <destFile>${project.build.directory}/jacoco.exec</destFile>
+                </configuration>
+              </execution>
+              <execution>
+                <id>report</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>report</goal>
+                </goals>
+                <configuration>
+                  <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                  <formats>
+                    <format>XML</format>
+                    <format>HTML</format>
+                  </formats>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>release</id>
       <build>

--- a/src/main/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionContext.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionContext.java
@@ -200,28 +200,8 @@ final class SearchProtectionContext {
 
     public void completeRequest() {
         validateFilterTopology();
-        if (mode == SearchCompilationMode.PAGE && paged) {
-            SearchPolicy.Paging.Page pageLimits = policy.paging().page();
-            if (!pageLimits.allowToManyCount() && !toManyPaths.isEmpty()) {
-                throw exceeded("paging.page.allow-to-many-count", toManyPaths.size(), 0);
-            }
-            requireAtMost("paging.page.max-to-many-paths", toManyPaths.size(), pageLimits.maxToManyPaths());
-            if (!pageLimits.allowDistinctCount() && distinct) {
-                throw exceeded("paging.page.allow-distinct-count", 1, 0);
-            }
-            requireAtMost("paging.page.max-joined-paths", joinedPaths.size(), pageLimits.maxJoinedPaths());
-        }
-        if (queryPresent) {
-            if (!queryLimits.allowWithToManyFilter() && !toManyPaths.isEmpty()) {
-                throw exceeded("query.allow-with-to-many-filter", toManyPaths.size(), 0);
-            }
-            if (!queryLimits.allowWithRelationSort() && relationSortOrders > 0) {
-                throw exceeded("query.allow-with-relation-sort", relationSortOrders, 0);
-            }
-            if (!queryLimits.allowWithUnpaged() && unpagedInput) {
-                throw exceeded("query.allow-with-unpaged", 1, 0);
-            }
-        }
+        validatePageRequest();
+        validateQueryRequest();
     }
 
     public int joinedPaths() {
@@ -251,6 +231,36 @@ final class SearchProtectionContext {
         requireAtMost("filter.max-to-many-paths", toManyPaths.size(), filterLimits.maxToManyPaths());
         if (!filterLimits.allowToManyFiltering() && !toManyPaths.isEmpty()) {
             throw exceeded("filter.allow-to-many-filtering", toManyPaths.size(), 0);
+        }
+    }
+
+    private void validatePageRequest() {
+        if (mode != SearchCompilationMode.PAGE || !paged) {
+            return;
+        }
+        SearchPolicy.Paging.Page pageLimits = policy.paging().page();
+        if (!pageLimits.allowToManyCount() && !toManyPaths.isEmpty()) {
+            throw exceeded("paging.page.allow-to-many-count", toManyPaths.size(), 0);
+        }
+        requireAtMost("paging.page.max-to-many-paths", toManyPaths.size(), pageLimits.maxToManyPaths());
+        if (!pageLimits.allowDistinctCount() && distinct) {
+            throw exceeded("paging.page.allow-distinct-count", 1, 0);
+        }
+        requireAtMost("paging.page.max-joined-paths", joinedPaths.size(), pageLimits.maxJoinedPaths());
+    }
+
+    private void validateQueryRequest() {
+        if (!queryPresent) {
+            return;
+        }
+        if (!queryLimits.allowWithToManyFilter() && !toManyPaths.isEmpty()) {
+            throw exceeded("query.allow-with-to-many-filter", toManyPaths.size(), 0);
+        }
+        if (!queryLimits.allowWithRelationSort() && relationSortOrders > 0) {
+            throw exceeded("query.allow-with-relation-sort", relationSortOrders, 0);
+        }
+        if (!queryLimits.allowWithUnpaged() && unpagedInput) {
+            throw exceeded("query.allow-with-unpaged", 1, 0);
         }
     }
 

--- a/src/main/java/io/github/ggomarighetti/searchhelper/definition/SearchDefinition.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/definition/SearchDefinition.java
@@ -372,7 +372,7 @@ public final class SearchDefinition<T> {
      */
     public static final class Fields<T> {
         private final Class<T> entity;
-        private final Map<String, SearchField.Builder<?>> fields = new LinkedHashMap<>();
+        private final Map<String, SearchField.Builder<?>> fieldBuilders = new LinkedHashMap<>();
 
         private Fields(Class<T> entity) {
             this.entity = entity;
@@ -391,7 +391,7 @@ public final class SearchDefinition<T> {
             Assert.notNull(type, "type must not be null");
 
             SearchField.Builder<V> field = SearchField.builder(entity, selector, type);
-            if (fields.putIfAbsent(selector, field) != null) {
+            if (fieldBuilders.putIfAbsent(selector, field) != null) {
                 throw new IllegalArgumentException("selector '%s' is already declared".formatted(selector));
             }
             return field;
@@ -415,7 +415,7 @@ public final class SearchDefinition<T> {
 
         private Map<String, SearchField<?>> build(SearchPolicy.Paths pathLimits) {
             Map<String, SearchField<?>> built = new LinkedHashMap<>();
-            fields.forEach((selector, field) -> built.put(selector, field.build(pathLimits)));
+            fieldBuilders.forEach((selector, field) -> built.put(selector, field.build(pathLimits)));
             return built;
         }
     }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/definition/SearchDefinitionFactory.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/definition/SearchDefinitionFactory.java
@@ -4,16 +4,14 @@ import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import java.util.Objects;
 
 /** Creates definition builders with application-wide path limits. */
-public final class SearchDefinitionFactory {
-    private final SearchPolicy policy;
-
+public record SearchDefinitionFactory(SearchPolicy policy) {
     /**
      * Creates a factory.
      *
      * @param policy application-wide policy
      */
-    public SearchDefinitionFactory(SearchPolicy policy) {
-        this.policy = Objects.requireNonNull(policy, "policy must not be null");
+    public SearchDefinitionFactory {
+        policy = Objects.requireNonNull(policy, "policy must not be null");
     }
 
     /**
@@ -23,14 +21,5 @@ public final class SearchDefinitionFactory {
      */
     public SearchDefinition.EntityStep builder() {
         return SearchDefinition.builder(policy);
-    }
-
-    /**
-     * Returns the factory policy.
-     *
-     * @return immutable application-wide policy
-     */
-    public SearchPolicy policy() {
-        return policy;
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlFilterValidationException.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlFilterValidationException.java
@@ -1,7 +1,6 @@
 package io.github.ggomarighetti.searchhelper.exception;
 
 import java.util.List;
-import java.util.Objects;
 
 /** Reports RSQL parse, policy, conversion, or semantic validation failures. */
 public final class RsqlFilterValidationException extends RuntimeException {
@@ -68,8 +67,8 @@ public final class RsqlFilterValidationException extends RuntimeException {
             List<RsqlValidationError> errors,
             Throwable cause) {
         super(message, cause);
-        this.code = requireCode(code);
-        this.errors = List.copyOf(Objects.requireNonNull(errors, "errors must not be null"));
+        this.code = ValidationExceptionSupport.requireCode(code);
+        this.errors = ValidationExceptionSupport.copyList(errors, "errors");
     }
 
     /**
@@ -88,12 +87,5 @@ public final class RsqlFilterValidationException extends RuntimeException {
      */
     public List<RsqlValidationError> errors() {
         return errors;
-    }
-
-    private static String requireCode(String code) {
-        if (Objects.requireNonNull(code, "code must not be null").isBlank()) {
-            throw new IllegalArgumentException("code must not be blank");
-        }
-        return code;
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/SearchDefinitionValidationException.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/SearchDefinitionValidationException.java
@@ -1,7 +1,5 @@
 package io.github.ggomarighetti.searchhelper.exception;
 
-import java.util.Objects;
-
 /** Reports an invalid search definition or incompatible engine/backend setup. */
 public final class SearchDefinitionValidationException extends RuntimeException {
     private static final long serialVersionUID = 1L;
@@ -32,7 +30,7 @@ public final class SearchDefinitionValidationException extends RuntimeException 
      */
     public SearchDefinitionValidationException(String code, String message) {
         super(message);
-        this.code = requireCode(code);
+        this.code = ValidationExceptionSupport.requireCode(code);
     }
 
     /**
@@ -44,7 +42,7 @@ public final class SearchDefinitionValidationException extends RuntimeException 
      */
     public SearchDefinitionValidationException(String code, String message, Throwable cause) {
         super(message, cause);
-        this.code = requireCode(code);
+        this.code = ValidationExceptionSupport.requireCode(code);
     }
 
     /**
@@ -53,13 +51,6 @@ public final class SearchDefinitionValidationException extends RuntimeException 
      * @return stable machine-readable error code
      */
     public String code() {
-        return code;
-    }
-
-    private static String requireCode(String code) {
-        if (Objects.requireNonNull(code, "code must not be null").isBlank()) {
-            throw new IllegalArgumentException("code must not be blank");
-        }
         return code;
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/SearchPageableValidationException.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/SearchPageableValidationException.java
@@ -44,7 +44,7 @@ public final class SearchPageableValidationException extends RuntimeException {
             List<RuleViolation> violations) {
         super(message);
         this.code = ValidationExceptionSupport.requireCode(code);
-        this.violations = ValidationExceptionSupport.copyViolations(violations);
+        this.violations = ValidationExceptionSupport.copyList(violations, "violations");
     }
 
     /**

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/SearchPageableValidationException.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/SearchPageableValidationException.java
@@ -2,7 +2,6 @@ package io.github.ggomarighetti.searchhelper.exception;
 
 import io.github.ggomarighetti.searchhelper.validation.RuleViolation;
 import java.util.List;
-import java.util.Objects;
 
 /** Reports pageable or sorting input rejected by definition or policy rules. */
 public final class SearchPageableValidationException extends RuntimeException {
@@ -44,8 +43,8 @@ public final class SearchPageableValidationException extends RuntimeException {
             String message,
             List<RuleViolation> violations) {
         super(message);
-        this.code = requireCode(code);
-        this.violations = List.copyOf(Objects.requireNonNull(violations, "violations must not be null"));
+        this.code = ValidationExceptionSupport.requireCode(code);
+        this.violations = ValidationExceptionSupport.copyViolations(violations);
     }
 
     /**
@@ -64,12 +63,5 @@ public final class SearchPageableValidationException extends RuntimeException {
      */
     public List<RuleViolation> violations() {
         return violations;
-    }
-
-    private static String requireCode(String code) {
-        if (Objects.requireNonNull(code, "code must not be null").isBlank()) {
-            throw new IllegalArgumentException("code must not be blank");
-        }
-        return code;
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/SearchQueryValidationException.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/SearchQueryValidationException.java
@@ -65,7 +65,7 @@ public final class SearchQueryValidationException extends RuntimeException {
             Throwable cause) {
         super(message, cause);
         this.code = ValidationExceptionSupport.requireCode(code);
-        this.violations = ValidationExceptionSupport.copyViolations(violations);
+        this.violations = ValidationExceptionSupport.copyList(violations, "violations");
     }
 
     /**

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/SearchQueryValidationException.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/SearchQueryValidationException.java
@@ -2,7 +2,6 @@ package io.github.ggomarighetti.searchhelper.exception;
 
 import io.github.ggomarighetti.searchhelper.validation.RuleViolation;
 import java.util.List;
-import java.util.Objects;
 
 /** Indicates that free-text query validation failed. */
 public final class SearchQueryValidationException extends RuntimeException {
@@ -65,8 +64,8 @@ public final class SearchQueryValidationException extends RuntimeException {
             List<RuleViolation> violations,
             Throwable cause) {
         super(message, cause);
-        this.code = requireCode(code);
-        this.violations = List.copyOf(Objects.requireNonNull(violations, "violations must not be null"));
+        this.code = ValidationExceptionSupport.requireCode(code);
+        this.violations = ValidationExceptionSupport.copyViolations(violations);
     }
 
     /**
@@ -85,12 +84,5 @@ public final class SearchQueryValidationException extends RuntimeException {
      */
     public List<RuleViolation> violations() {
         return violations;
-    }
-
-    private static String requireCode(String code) {
-        if (Objects.requireNonNull(code, "code must not be null").isBlank()) {
-            throw new IllegalArgumentException("code must not be blank");
-        }
-        return code;
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/ValidationExceptionSupport.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/ValidationExceptionSupport.java
@@ -1,6 +1,5 @@
 package io.github.ggomarighetti.searchhelper.exception;
 
-import io.github.ggomarighetti.searchhelper.validation.RuleViolation;
 import java.util.List;
 import java.util.Objects;
 
@@ -15,7 +14,7 @@ final class ValidationExceptionSupport {
         return code;
     }
 
-    static List<RuleViolation> copyViolations(List<RuleViolation> violations) {
-        return List.copyOf(Objects.requireNonNull(violations, "violations must not be null"));
+    static <T> List<T> copyList(List<T> values, String parameterName) {
+        return List.copyOf(Objects.requireNonNull(values, parameterName + " must not be null"));
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/ValidationExceptionSupport.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/ValidationExceptionSupport.java
@@ -1,0 +1,21 @@
+package io.github.ggomarighetti.searchhelper.exception;
+
+import io.github.ggomarighetti.searchhelper.validation.RuleViolation;
+import java.util.List;
+import java.util.Objects;
+
+final class ValidationExceptionSupport {
+    private ValidationExceptionSupport() {
+    }
+
+    static String requireCode(String code) {
+        if (Objects.requireNonNull(code, "code must not be null").isBlank()) {
+            throw new IllegalArgumentException("code must not be blank");
+        }
+        return code;
+    }
+
+    static List<RuleViolation> copyViolations(List<RuleViolation> violations) {
+        return List.copyOf(Objects.requireNonNull(violations, "violations must not be null"));
+    }
+}

--- a/src/main/java/io/github/ggomarighetti/searchhelper/filter/FilterOperator.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/filter/FilterOperator.java
@@ -168,7 +168,7 @@ public final class FilterOperator<T> {
      * @param <T> value type validated by the rules
      */
     public static final class Rules<T> {
-        private final List<ConstraintDef<?, ?>> rules = new ArrayList<>();
+        private final List<ConstraintDef<?, ?>> constraints = new ArrayList<>();
 
         /** Creates an empty rule declaration. */
         public Rules() {
@@ -182,12 +182,12 @@ public final class FilterOperator<T> {
          * @return this declaration
          */
         public Rules<T> rule(ConstraintDef<?, ?> rule) {
-            rules.add(Objects.requireNonNull(rule, "rule must not be null"));
+            constraints.add(Objects.requireNonNull(rule, "rule must not be null"));
             return this;
         }
 
         private List<ConstraintDef<?, ?>> rules() {
-            return List.copyOf(rules);
+            return List.copyOf(constraints);
         }
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/jpa/JpaSearchDefinitionValidator.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/jpa/JpaSearchDefinitionValidator.java
@@ -132,12 +132,11 @@ public final class JpaSearchDefinitionValidator implements SearchDefinitionValid
             String capability,
             String path,
             Throwable cause) {
-        SearchDefinitionValidationException exception = new SearchDefinitionValidationException(
+        return new SearchDefinitionValidationException(
                 SearchDefinitionValidationException.JPA_PATH_UNRESOLVED,
                 "selector '%s' %s path '%s' could not be resolved against JPA entity '%s'"
                         .formatted(selector, capability, path, entity.getName()),
                 cause);
-        return exception;
     }
 
     private static SearchDefinitionValidationException unresolvedEntity(Class<?> entity, Throwable cause) {

--- a/src/main/java/io/github/ggomarighetti/searchhelper/page/SearchPaging.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/page/SearchPaging.java
@@ -155,7 +155,7 @@ public final class SearchPaging {
      * @param <T> validated value type
      */
     public static final class Rules<T> {
-        private final List<ConstraintDef<?, ?>> rules = new ArrayList<>();
+        private final List<ConstraintDef<?, ?>> constraints = new ArrayList<>();
 
         /** Creates an empty rule declaration. */
         public Rules() {
@@ -169,12 +169,12 @@ public final class SearchPaging {
          * @return this declaration
          */
         public Rules<T> rule(ConstraintDef<?, ?> rule) {
-            rules.add(Objects.requireNonNull(rule, "rule must not be null"));
+            constraints.add(Objects.requireNonNull(rule, "rule must not be null"));
             return this;
         }
 
         private List<ConstraintDef<?, ?>> rules() {
-            return List.copyOf(rules);
+            return List.copyOf(constraints);
         }
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
@@ -88,7 +88,7 @@ public final class PerplexhubRsqlBackendAdapter implements RsqlBackendAdapter {
     private static RSQLCustomPredicate<?> customPredicate(
             RsqlOperatorDescriptor descriptor,
             RsqlJpaPredicateFactory factory) {
-        Class<? extends Comparable<?>> type = descriptor.argumentType().orElse((Class) String.class);
+        Class<? extends Comparable<?>> type = descriptor.argumentType().orElse(String.class);
         Function<RSQLCustomPredicateInput, Predicate> converter =
                 input -> factory.toPredicate(context(input, descriptor.operator()));
         return new RSQLCustomPredicate(

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/operator/RsqlOperatorRegistry.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/operator/RsqlOperatorRegistry.java
@@ -25,7 +25,7 @@ public final class RsqlOperatorRegistry {
         Objects.requireNonNull(descriptors, "descriptors must not be null");
         Map<RsqlOperator, RsqlOperatorDescriptor> operators = new LinkedHashMap<>();
         Map<String, RsqlOperatorDescriptor> symbols = new LinkedHashMap<>();
-        Set<ComparisonOperator> parserOperators = new LinkedHashSet<>();
+        Set<ComparisonOperator> parsedOperators = new LinkedHashSet<>();
         for (RsqlOperatorDescriptor descriptor : descriptors) {
             RsqlOperatorDescriptor previous = operators.putIfAbsent(descriptor.operator(), descriptor);
             if (previous != null) {
@@ -37,11 +37,11 @@ public final class RsqlOperatorRegistry {
                     throw new IllegalArgumentException("RSQL symbol '%s' is already registered".formatted(symbol));
                 }
             }
-            parserOperators.add(descriptor.comparisonOperator());
+            parsedOperators.add(descriptor.comparisonOperator());
         }
         this.byOperator = Collections.unmodifiableMap(operators);
         this.bySymbol = Collections.unmodifiableMap(symbols);
-        this.parserOperators = Collections.unmodifiableSet(parserOperators);
+        this.parserOperators = Collections.unmodifiableSet(parsedOperators);
     }
 
     /**

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/PersonSubtypeSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/PersonSubtypeSearchPostgresIT.java
@@ -10,6 +10,7 @@ import io.github.ggomarighetti.searchhelper.integration.inheritance.domain.Perso
 import io.github.ggomarighetti.searchhelper.integration.postgres.PostgresTestEnvironment;
 import io.github.ggomarighetti.searchhelper.jpa.JpaSearchDefinitionValidator;
 import java.time.LocalDate;
+import java.time.Month;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,8 +48,8 @@ class PersonSubtypeSearchPostgresIT {
 
     @BeforeEach
     void seedPeople() {
-        entityManager.persist(new NaturalPerson("Ana", LocalDate.of(1985, 6, 15)));
-        entityManager.persist(new NaturalPerson("Bruno", LocalDate.of(2001, 2, 3)));
+        entityManager.persist(new NaturalPerson("Ana", LocalDate.of(1985, Month.JUNE, 15)));
+        entityManager.persist(new NaturalPerson("Bruno", LocalDate.of(2001, Month.FEBRUARY, 3)));
         entityManager.persist(new LegalPerson("Acme", "REG-001"));
         entityManager.flush();
         entityManager.clear();

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/bench/dao/ProductSeeder.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/bench/dao/ProductSeeder.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.function.Consumer;
 import java.util.UUID;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
@@ -124,7 +125,7 @@ public final class ProductSeeder {
                 .price(amount("499.00"))
                 .active(true)
                 .archived(false)
-                .releaseDate(LocalDate.of(2024, 1, 15))
+                .releaseDate(LocalDate.of(2024, Month.JANUARY, 15))
                 .status(Status.PUBLISHED)
                 .category(category)
                 .supplier(supplier)

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/bench/domain/Product.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/bench/domain/Product.java
@@ -88,7 +88,7 @@ public class Product {
 
     @Transient
     public String getDisplayName() {
-        return name;
+        return getName();
     }
 
     Product(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
@@ -10,6 +10,7 @@ import java.sql.PreparedStatement;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -47,7 +48,7 @@ public final class ProductPlanSeeder {
     }
 
     public static LocalDate releaseDate(long id) {
-        return LocalDate.of(2020, 1, 1).plusDays(id % 1_800);
+        return LocalDate.of(2020, Month.JANUARY, 1).plusDays(id % 1_800);
     }
 
     private static void seedCategories(JdbcTemplate jdbcTemplate) {

--- a/src/test/java/io/github/ggomarighetti/searchhelper/property/RsqlInputGenerator.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/property/RsqlInputGenerator.java
@@ -109,10 +109,15 @@ public final class RsqlInputGenerator {
     private String grouped() {
         String input = comparison();
         int groups = random.nextInt(5);
+        StringBuilder builder = new StringBuilder(input.length() + groups * 2);
         for (int i = 0; i < groups; i++) {
-            input = "(" + input + ")";
+            builder.append('(');
         }
-        return input;
+        builder.append(input);
+        for (int i = 0; i < groups; i++) {
+            builder.append(')');
+        }
+        return builder.toString();
     }
 
     private String comparison() {

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/TestTypes.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/TestTypes.java
@@ -1,8 +1,5 @@
 package io.github.ggomarighetti.searchhelper.unit;
 
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Review;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Status;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;


### PR DESCRIPTION
### Resume

- Adds a Maven `coverage` profile powered by JaCoCo for unit and integration test coverage.
- Updates the Verify workflow to generate coverage, upload JaCoCo and JUnit XML reports to Codecov, and run SonarQube Cloud analysis when `SONAR_TOKEN` is configured.
- Documents the local coverage command and generated report locations.

### Evidence

- `./mvnw -B -ntp -Pcoverage verify` passed locally with JDK 25.
- Tests: 147 unit tests and 32 integration tests passed.
- JaCoCo generated `target/site/jacoco/jacoco.xml` and `target/site/jacoco/index.html`; local line coverage was 86.8%.

### Reference

- SonarQube Cloud Java coverage docs: https://docs.sonarsource.com/sonarqube-cloud/analyzing-source-code/test-coverage/java-test-coverage
- Codecov GitHub Action docs: https://github.com/codecov/codecov-action