### PR TITLE
fix: resolve search helper validation and test quality issues

### DIFF
--- a/src/main/java/io/github/ggomarighetti/searchhelper/definition/SearchDefinitionFactory.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/definition/SearchDefinitionFactory.java
@@ -11,7 +11,7 @@ public record SearchDefinitionFactory(SearchPolicy policy) {
      * @param policy application-wide policy
      */
     public SearchDefinitionFactory {
-        policy = Objects.requireNonNull(policy, "policy must not be null");
+        Objects.requireNonNull(policy, "policy must not be null");
     }
 
     /**

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlValidationError.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlValidationError.java
@@ -40,7 +40,7 @@ public record RsqlValidationError(
     public RsqlValidationError {
         requireText(code, "code");
         requireText(astPath, "astPath");
-        message = requireText(message, "message");
+        requireText(message, "message");
         if (argumentIndex != null && argumentIndex < 0) {
             throw new IllegalArgumentException("argumentIndex must not be negative");
         }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlValidationError.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlValidationError.java
@@ -39,7 +39,7 @@ public record RsqlValidationError(
     /** Validates required location and message fields. */
     public RsqlValidationError {
         requireText(code, "code");
-        astPath = requireText(astPath, "astPath");
+        requireText(astPath, "astPath");
         message = requireText(message, "message");
         if (argumentIndex != null && argumentIndex < 0) {
             throw new IllegalArgumentException("argumentIndex must not be negative");

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlValidationError.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlValidationError.java
@@ -38,7 +38,7 @@ public record RsqlValidationError(
 
     /** Validates required location and message fields. */
     public RsqlValidationError {
-        code = requireText(code, "code");
+        requireText(code, "code");
         astPath = requireText(astPath, "astPath");
         message = requireText(message, "message");
         if (argumentIndex != null && argumentIndex < 0) {

--- a/src/main/java/io/github/ggomarighetti/searchhelper/filter/DefaultFilterOperators.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/filter/DefaultFilterOperators.java
@@ -21,9 +21,7 @@ import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.Calendar;
 import java.util.Currency;
-import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Objects;
@@ -101,8 +99,6 @@ public final class DefaultFilterOperators {
             Double.class,
             BigInteger.class,
             BigDecimal.class,
-            Date.class,
-            Calendar.class,
             Instant.class,
             LocalDate.class,
             LocalDateTime.class,

--- a/src/main/java/io/github/ggomarighetti/searchhelper/filter/FilterValidationError.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/filter/FilterValidationError.java
@@ -20,7 +20,7 @@ public record FilterValidationError(
         RuleViolation violation) {
     /** Validates the fields required by the selected error code. */
     public FilterValidationError {
-        code = Objects.requireNonNull(code, "code must not be null");
+        Objects.requireNonNull(code, "code must not be null");
         if (argumentIndex != null && argumentIndex < 0) {
             throw new IllegalArgumentException("argumentIndex must not be negative");
         }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/policy/SearchPolicy.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/policy/SearchPolicy.java
@@ -961,7 +961,7 @@ public final class SearchPolicy {
             requirePositive(defaultUnpagedSize, "paging.defaultUnpagedSize");
             requirePositive(maxUnpagedSize, "paging.maxUnpagedSize");
             Objects.requireNonNull(page, "paging.page must not be null");
-            slice = Objects.requireNonNull(slice, "paging.slice must not be null");
+            Objects.requireNonNull(slice, "paging.slice must not be null");
             if (maxPage < minPage) {
                 throw new IllegalArgumentException("paging.maxPage must be greater than or equal to paging.minPage");
             }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/policy/SearchPolicy.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/policy/SearchPolicy.java
@@ -481,7 +481,7 @@ public final class SearchPolicy {
             requireNonNegative(maxHeterogeneousOrBranches, "filter.maxHeterogeneousOrBranches");
             requireNonNegative(maxJoinedPaths, "filter.maxJoinedPaths");
             requireNonNegative(maxToManyPaths, "filter.maxToManyPaths");
-            like = Objects.requireNonNull(like, "filter.like must not be null");
+            Objects.requireNonNull(like, "filter.like must not be null");
         }
 
         /**

--- a/src/main/java/io/github/ggomarighetti/searchhelper/policy/SearchPolicy.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/policy/SearchPolicy.java
@@ -960,7 +960,7 @@ public final class SearchPolicy {
             requireNonNegative(maxOffset, "paging.maxOffset");
             requirePositive(defaultUnpagedSize, "paging.defaultUnpagedSize");
             requirePositive(maxUnpagedSize, "paging.maxUnpagedSize");
-            page = Objects.requireNonNull(page, "paging.page must not be null");
+            Objects.requireNonNull(page, "paging.page must not be null");
             slice = Objects.requireNonNull(slice, "paging.slice must not be null");
             if (maxPage < minPage) {
                 throw new IllegalArgumentException("paging.maxPage must be greater than or equal to paging.minPage");

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlComparison.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlComparison.java
@@ -16,7 +16,7 @@ public record RsqlComparison(String selector, RsqlOperator operator, List<String
     /** Validates and snapshots comparison data. */
     public RsqlComparison {
         Assert.hasText(selector, "selector must not be blank");
-        operator = Objects.requireNonNull(operator, "operator must not be null");
+        Objects.requireNonNull(operator, "operator must not be null");
         arguments = List.copyOf(Objects.requireNonNull(arguments, "arguments must not be null"));
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
@@ -30,6 +30,6 @@ public record RsqlCompilationRequest<T>(
         Objects.requireNonNull(ast, "ast must not be null");
         Objects.requireNonNull(definition, "definition must not be null");
         Objects.requireNonNull(conversionService, "conversionService must not be null");
-        operators = Objects.requireNonNull(operators, "operators must not be null");
+        Objects.requireNonNull(operators, "operators must not be null");
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
@@ -29,7 +29,7 @@ public record RsqlCompilationRequest<T>(
         Assert.hasText(rsql, "rsql must not be blank");
         Objects.requireNonNull(ast, "ast must not be null");
         Objects.requireNonNull(definition, "definition must not be null");
-        conversionService = Objects.requireNonNull(conversionService, "conversionService must not be null");
+        Objects.requireNonNull(conversionService, "conversionService must not be null");
         operators = Objects.requireNonNull(operators, "operators must not be null");
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
@@ -27,7 +27,7 @@ public record RsqlCompilationRequest<T>(
     /** Validates required request components. */
     public RsqlCompilationRequest {
         Assert.hasText(rsql, "rsql must not be blank");
-        ast = Objects.requireNonNull(ast, "ast must not be null");
+        Objects.requireNonNull(ast, "ast must not be null");
         definition = Objects.requireNonNull(definition, "definition must not be null");
         conversionService = Objects.requireNonNull(conversionService, "conversionService must not be null");
         operators = Objects.requireNonNull(operators, "operators must not be null");

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
@@ -28,7 +28,7 @@ public record RsqlCompilationRequest<T>(
     public RsqlCompilationRequest {
         Assert.hasText(rsql, "rsql must not be blank");
         Objects.requireNonNull(ast, "ast must not be null");
-        definition = Objects.requireNonNull(definition, "definition must not be null");
+        Objects.requireNonNull(definition, "definition must not be null");
         conversionService = Objects.requireNonNull(conversionService, "conversionService must not be null");
         operators = Objects.requireNonNull(operators, "operators must not be null");
     }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
@@ -9,9 +9,9 @@ import java.util.List;
 import java.util.Objects;
 
 /** JPA state and converted arguments supplied to a custom operator predicate. */
-public record RsqlJpaPredicateContext(
+public record RsqlJpaPredicateContext<P>(
         CriteriaBuilder criteriaBuilder,
-        Path<?> path,
+        Path<P> path,
         Attribute<?, ?> attribute,
         List<Object> arguments,
         From<?, ?> root,

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
@@ -9,12 +9,12 @@ import java.util.List;
 import java.util.Objects;
 
 /** JPA state and converted arguments supplied to a custom operator predicate. */
-public record RsqlJpaPredicateContext<P, A, B>(
+public record RsqlJpaPredicateContext<P, A, B, R, J>(
         CriteriaBuilder criteriaBuilder,
         Path<P> path,
         Attribute<A, B> attribute,
         List<Object> arguments,
-        From<?, ?> root,
+        From<R, J> root,
         RsqlOperator operator) {
     /** Creates a custom-predicate context. */
     public RsqlJpaPredicateContext {

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
@@ -9,91 +9,20 @@ import java.util.List;
 import java.util.Objects;
 
 /** JPA state and converted arguments supplied to a custom operator predicate. */
-public final class RsqlJpaPredicateContext {
-    private final CriteriaBuilder criteriaBuilder;
-    private final Path<?> path;
-    private final Attribute<?, ?> attribute;
-    private final List<Object> arguments;
-    private final From<?, ?> root;
-    private final RsqlOperator operator;
-
-    /**
-     * Creates a custom-predicate context.
-     *
-     * @param criteriaBuilder active criteria builder
-     * @param path resolved JPA path for the public selector
-     * @param attribute terminal metamodel attribute, when available
-     * @param arguments immutable converted arguments
-     * @param root criteria root or treated subtype root
-     * @param operator logical operator being executed
-     */
-    public RsqlJpaPredicateContext(
-            CriteriaBuilder criteriaBuilder,
-            Path<?> path,
-            Attribute<?, ?> attribute,
-            List<Object> arguments,
-            From<?, ?> root,
-            RsqlOperator operator) {
-        this.criteriaBuilder = Objects.requireNonNull(criteriaBuilder, "criteriaBuilder must not be null");
-        this.path = Objects.requireNonNull(path, "path must not be null");
-        this.attribute = attribute;
-        this.arguments = List.copyOf(Objects.requireNonNull(arguments, "arguments must not be null"));
-        this.root = Objects.requireNonNull(root, "root must not be null");
-        this.operator = Objects.requireNonNull(operator, "operator must not be null");
-    }
-
-    /**
-     * Returns the active criteria builder.
-     *
-     * @return active criteria builder
-     */
-    public CriteriaBuilder criteriaBuilder() {
-        return criteriaBuilder;
-    }
-
-    /**
-     * Returns the resolved selector path.
-     *
-     * @return resolved path for the selector
-     */
-    public Path<?> path() {
-        return path;
-    }
-
-    /**
-     * Returns terminal metamodel information.
-     *
-     * @return terminal metamodel attribute, or {@code null}
-     */
-    public Attribute<?, ?> attribute() {
-        return attribute;
-    }
-
-    /**
-     * Returns all converted arguments.
-     *
-     * @return immutable converted argument list
-     */
-    public List<Object> arguments() {
-        return arguments;
-    }
-
-    /**
-     * Returns the path root.
-     *
-     * @return criteria root used to resolve the path
-     */
-    public From<?, ?> root() {
-        return root;
-    }
-
-    /**
-     * Returns the executing operator.
-     *
-     * @return logical operator being executed
-     */
-    public RsqlOperator operator() {
-        return operator;
+public record RsqlJpaPredicateContext(
+        CriteriaBuilder criteriaBuilder,
+        Path<?> path,
+        Attribute<?, ?> attribute,
+        List<Object> arguments,
+        From<?, ?> root,
+        RsqlOperator operator) {
+    /** Creates a custom-predicate context. */
+    public RsqlJpaPredicateContext {
+        Objects.requireNonNull(criteriaBuilder, "criteriaBuilder must not be null");
+        Objects.requireNonNull(path, "path must not be null");
+        arguments = List.copyOf(Objects.requireNonNull(arguments, "arguments must not be null"));
+        Objects.requireNonNull(root, "root must not be null");
+        Objects.requireNonNull(operator, "operator must not be null");
     }
 
     /**

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
@@ -9,10 +9,10 @@ import java.util.List;
 import java.util.Objects;
 
 /** JPA state and converted arguments supplied to a custom operator predicate. */
-public record RsqlJpaPredicateContext<P>(
+public record RsqlJpaPredicateContext<P, A, B>(
         CriteriaBuilder criteriaBuilder,
         Path<P> path,
-        Attribute<?, ?> attribute,
+        Attribute<A, B> attribute,
         List<Object> arguments,
         From<?, ?> root,
         RsqlOperator operator) {

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateFactory.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateFactory.java
@@ -13,5 +13,5 @@ public interface RsqlJpaPredicateFactory {
      * @param context custom predicate context
      * @return JPA predicate
      */
-    Predicate toPredicate(RsqlJpaPredicateContext context);
+    Predicate toPredicate(RsqlJpaPredicateContext<?, ?, ?, ?, ?> context);
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
@@ -97,8 +97,8 @@ public final class PerplexhubRsqlBackendAdapter implements RsqlBackendAdapter {
                 converter);
     }
 
-    private static RsqlJpaPredicateContext context(RSQLCustomPredicateInput input, RsqlOperator operator) {
-        return new RsqlJpaPredicateContext(
+    private static RsqlJpaPredicateContext<?, ?, ?, ?, ?> context(RSQLCustomPredicateInput input, RsqlOperator operator) {
+        return new RsqlJpaPredicateContext<>(
                 input.getCriteriaBuilder(),
                 input.getPath(),
                 input.getAttribute(),

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
@@ -175,7 +175,7 @@ public final class PerplexhubRsqlBackendAdapter implements RsqlBackendAdapter {
                 ComparisonNode comparison,
                 RSQLJPAPredicateConverter converter,
                 From<?, ?> root) {
-            return (Predicate) comparison.accept(converter, (From) root);
+            return (Predicate) comparison.accept(converter, root);
         }
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/operator/RsqlOperatorDescriptor.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/operator/RsqlOperatorDescriptor.java
@@ -3,7 +3,6 @@ package io.github.ggomarighetti.searchhelper.rsql.operator;
 import cz.jirutka.rsql.parser.ast.ComparisonOperator;
 import io.github.ggomarighetti.searchhelper.rsql.backend.RsqlJpaPredicateFactory;
 import java.util.Collections;
-import java.util.function.Consumer;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Optional;

--- a/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
@@ -26,7 +26,7 @@ public record RuleViolation(
         Objects.requireNonNull(path, "path must not be null");
         Objects.requireNonNull(message, "message must not be null");
         Objects.requireNonNull(messageTemplate, "messageTemplate must not be null");
-        constraint = Objects.requireNonNull(constraint, "constraint must not be null");
+        Objects.requireNonNull(constraint, "constraint must not be null");
     }
 
     /**

--- a/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
@@ -23,7 +23,7 @@ public record RuleViolation(
 
     /** Validates all safe violation fields. */
     public RuleViolation {
-        path = Objects.requireNonNull(path, "path must not be null");
+        Objects.requireNonNull(path, "path must not be null");
         message = Objects.requireNonNull(message, "message must not be null");
         messageTemplate = Objects.requireNonNull(messageTemplate, "messageTemplate must not be null");
         constraint = Objects.requireNonNull(constraint, "constraint must not be null");

--- a/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
@@ -24,7 +24,7 @@ public record RuleViolation(
     /** Validates all safe violation fields. */
     public RuleViolation {
         Objects.requireNonNull(path, "path must not be null");
-        message = Objects.requireNonNull(message, "message must not be null");
+        Objects.requireNonNull(message, "message must not be null");
         messageTemplate = Objects.requireNonNull(messageTemplate, "messageTemplate must not be null");
         constraint = Objects.requireNonNull(constraint, "constraint must not be null");
     }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
@@ -25,7 +25,7 @@ public record RuleViolation(
     public RuleViolation {
         Objects.requireNonNull(path, "path must not be null");
         Objects.requireNonNull(message, "message must not be null");
-        messageTemplate = Objects.requireNonNull(messageTemplate, "messageTemplate must not be null");
+        Objects.requireNonNull(messageTemplate, "messageTemplate must not be null");
         constraint = Objects.requireNonNull(constraint, "constraint must not be null");
     }
 

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
@@ -9,7 +9,6 @@ import io.github.ggomarighetti.searchhelper.rsql.backend.RsqlBackendAdapter;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperator;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorArity;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorDescriptor;
-import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
 import io.github.ggomarighetti.searchhelper.rsql.RsqlCompilationRequest;
 import io.github.ggomarighetti.searchhelper.rsql.SearchRsqlEngine;
 import io.github.ggomarighetti.searchhelper.rsql.SearchRsqlEngineBuilder;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
@@ -204,12 +204,13 @@ class SearchRsqlAutoConfigurationTest {
             assertEquals(new CatalogCode("CAT123"),
                     engine.conversionService().convert("CAT123", CatalogCode.class));
 
+            PageRequest pageRequest = PageRequest.of(0, 10);
             RsqlFilterValidationException exception = assertThrows(
                     RsqlFilterValidationException.class,
                     () -> compiler.compile(
                             "code==BAD",
                             null,
-                            PageRequest.of(0, 10),
+                            pageRequest,
                             definition));
 
             assertEquals(RsqlFilterValidationException.RULES_FORBIDDEN, exception.code());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
@@ -167,12 +167,13 @@ class SearchRsqlAutoConfigurationTest {
                     .paging()
                     .build();
 
+            PageRequest pageRequest = PageRequest.of(0, 10);
             SearchDefinitionValidationException exception = assertThrows(
                     SearchDefinitionValidationException.class,
                     () -> compiler.compile(
                             "code==CAT123",
                             null,
-                            PageRequest.of(0, 10),
+                            pageRequest,
                             definition));
 
             assertEquals(SearchDefinitionValidationException.RSQL_CONFIGURATION_INVALID, exception.code());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
@@ -69,9 +69,10 @@ class SearchRsqlAutoConfigurationTest {
             compiler.compile("sku==SKU123", null, PageRequest.of(0, 10), definition);
             assertEquals(new Sku("SKU123"), engine.conversionService().convert("SKU123", Sku.class));
 
+            PageRequest pageRequest = PageRequest.of(0, 10);
             RsqlFilterValidationException exception =
                     assertThrows(RsqlFilterValidationException.class, () ->
-                            compiler.compile("sku==BAD", null, PageRequest.of(0, 10), definition));
+                            compiler.compile("sku==BAD", null, pageRequest, definition));
 
             assertEquals(RsqlFilterValidationException.RULES_FORBIDDEN, exception.code());
         });

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/SearchHelperAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/SearchHelperAutoConfigurationTest.java
@@ -74,12 +74,13 @@ class SearchHelperAutoConfigurationTest {
                             .paging()
                             .build();
 
+                    var pageRequest = org.springframework.data.domain.PageRequest.of(0, 25);
                     assertThrows(
                             SearchProtectionException.class,
                             () -> compiler.compile(
                                     "taxId=in=(1,2)",
                                     null,
-                                    org.springframework.data.domain.PageRequest.of(0, 25),
+                                    pageRequest,
                                     definition));
                 });
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/SearchHelperAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/SearchHelperAutoConfigurationTest.java
@@ -4,7 +4,6 @@ import io.github.ggomarighetti.searchhelper.compile.SearchCompiler;
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinitionFactory;
 import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.unit.TestTypes;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
@@ -47,13 +47,12 @@ class RsqlPropertyTest {
 
         for (int i = 0; i < 250; i++) {
             String input = generator.comparisonWithUnknownSelector();
-            try {
-                guard.specification(input, definition);
-                fail("Unknown selector unexpectedly compiled: " + escaped(input));
-            } catch (Throwable throwable) {
-                if (!SearchPropertyFixtures.isExpectedRsqlThrowable(throwable)) {
-                    fail("Unexpected throwable for unknown selector input [" + escaped(input) + "]", throwable);
-                }
+            Throwable throwable = assertThrows(
+                    Throwable.class,
+                    () -> guard.specification(input, definition),
+                    "Unknown selector unexpectedly compiled: " + escaped(input));
+            if (!SearchPropertyFixtures.isExpectedRsqlThrowable(throwable)) {
+                fail("Unexpected throwable for unknown selector input [" + escaped(input) + "]", throwable);
             }
         }
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
@@ -65,13 +65,12 @@ class RsqlPropertyTest {
 
         for (int i = 0; i < 250; i++) {
             String input = generator.comparisonWithDisallowedOperator();
-            try {
-                guard.specification(input, definition);
-                fail("Disallowed operator unexpectedly compiled: " + escaped(input));
-            } catch (Throwable throwable) {
-                if (!SearchPropertyFixtures.isExpectedRsqlThrowable(throwable)) {
-                    fail("Unexpected throwable for disallowed operator input [" + escaped(input) + "]", throwable);
-                }
+            Throwable throwable = assertThrows(
+                    Throwable.class,
+                    () -> guard.specification(input, definition),
+                    "Disallowed operator unexpectedly compiled: " + escaped(input));
+            if (!SearchPropertyFixtures.isExpectedRsqlThrowable(throwable)) {
+                fail("Unexpected throwable for disallowed operator input [" + escaped(input) + "]", throwable);
             }
         }
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
@@ -203,8 +203,9 @@ class RsqlPropertyTest {
             String input,
             SearchDefinition<Product> definition,
             String expectedRule) {
+        RsqlSearchGuard guard = new RsqlSearchGuard();
         SearchProtectionException exception =
-                assertThrows(SearchProtectionException.class, () -> new RsqlSearchGuard().specification(input, definition));
+                assertThrows(SearchProtectionException.class, () -> guard.specification(input, definition));
         assertEquals(SearchProtectionException.PROTECTION_RULE_EXCEEDED, exception.code(), input);
         assertEquals(expectedRule, exception.rule(), input);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
@@ -193,8 +193,9 @@ class RsqlPropertyTest {
     }
 
     private static void assertLimitExceeded(String input, SearchDefinition<Product> definition) {
+        RsqlSearchGuard guard = new RsqlSearchGuard();
         RsqlFilterValidationException exception =
-                assertThrows(RsqlFilterValidationException.class, () -> new RsqlSearchGuard().specification(input, definition));
+                assertThrows(RsqlFilterValidationException.class, () -> guard.specification(input, definition));
         assertEquals(RsqlFilterValidationException.LIMIT_EXCEEDED, exception.code(), input);
     }
 

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
@@ -1,6 +1,5 @@
 package io.github.ggomarighetti.searchhelper.compile;
 
-import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.EQUAL;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -211,7 +211,7 @@ class RsqlSearchGuardTest {
 
         assertEquals("=first=", descriptor.symbol());
         assertEquals(List.of("=first=", "=second="), descriptor.symbols().stream().toList());
-        Set<String> symbols = descriptor.symbols();
+        var symbols = descriptor.symbols();
         assertThrows(UnsupportedOperationException.class, symbols::clear);
     }
 

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -475,10 +475,11 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsRsqlArgumentLimitsBeforeConversionAndRules() {
+        SearchDefinition<TestTypes.Product> perComparisonDefinition = filters(limits -> limits
+                .filter(filter -> filter.maxArgumentsPerComparison(1)));
         SearchProtectionException perComparison = assertThrows(
                 SearchProtectionException.class,
-                () -> guard.specification("taxId=in=(20123456789,20987654321)", filters(limits -> limits
-                        .filter(filter -> filter.maxArgumentsPerComparison(1)))));
+                () -> guard.specification("taxId=in=(20123456789,20987654321)", perComparisonDefinition));
         SearchProtectionException total = assertThrows(
                 SearchProtectionException.class,
                 () -> guard.specification(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -10,7 +10,6 @@ import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.rsql.backend.RsqlBackendAdapter;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperator;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorDescriptor;
-import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
 import io.github.ggomarighetti.searchhelper.rsql.RsqlCompilationRequest;
 import io.github.ggomarighetti.searchhelper.unit.TestTypes;
 import io.github.ggomarighetti.searchhelper.rsql.SearchRsqlEngine;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -404,10 +404,11 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsRsqlRawInputLongerThanLimit() {
+        SearchDefinition<TestTypes.Product> definition = filters(limits -> limits
+                .rsql(rsql -> rsql.maxLength(10)));
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("taxId==20123456789", filters(limits -> limits
-                        .rsql(rsql -> rsql.maxLength(10)))));
+                () -> guard.specification("taxId==20123456789", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.LIMIT_EXCEEDED);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -375,9 +375,10 @@ class RsqlSearchGuardTest {
 
     @Test
     void returnsRulesForbiddenWhenParsedFilterBreaksMultipleRules() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("passwordHash==abc;email!=not-an-email", filters()));
+                () -> guard.specification("passwordHash==abc;email!=not-an-email", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
         assertEquals(2, exception.errors().size());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -480,11 +480,13 @@ class RsqlSearchGuardTest {
         SearchProtectionException perComparison = assertThrows(
                 SearchProtectionException.class,
                 () -> guard.specification("taxId=in=(20123456789,20987654321)", perComparisonDefinition));
+        SearchDefinition<TestTypes.Product> totalDefinition =
+                filters(limits -> limits.filter(filter -> filter.maxArgumentsTotal(3)));
         SearchProtectionException total = assertThrows(
                 SearchProtectionException.class,
                 () -> guard.specification(
                         "taxId=in=(20123456789,20987654321);taxId=in=(30123456789,30987654321)",
-                        filters(limits -> limits.filter(filter -> filter.maxArgumentsTotal(3)))));
+                        totalDefinition));
         SearchProtectionException length = assertThrows(
                 SearchProtectionException.class,
                 () -> guard.specification("email==person@example.com", filters(limits -> limits

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -437,9 +437,10 @@ class RsqlSearchGuardTest {
     void rejectsRsqlAstNodeComparisonDepthAndLogicalChildLimits() {
         String filter = "taxId==20123456789;email==person@example.com";
 
+        SearchDefinition<TestTypes.Product> nodesDefinition = filters(limits -> limits.rsql(rsql -> rsql.maxNodes(1)));
         RsqlFilterValidationException nodes = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification(filter, filters(limits -> limits.rsql(rsql -> rsql.maxNodes(1)))));
+                () -> guard.specification(filter, nodesDefinition));
         SearchProtectionException comparisons = assertThrows(
                 SearchProtectionException.class,
                 () -> guard.specification(filter, filters(limits -> limits.filter(value -> value.maxComparisons(1)))));

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -330,9 +330,10 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsOperatorNotAllowedForField() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("taxId!=20123456789", filters()));
+                () -> guard.specification("taxId!=20123456789", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
         RsqlValidationError error = exception.errors().get(0);

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -450,10 +450,11 @@ class RsqlSearchGuardTest {
         RsqlFilterValidationException depth = assertThrows(
                 RsqlFilterValidationException.class,
                 () -> guard.specification(filter, depthDefinition));
+        SearchDefinition<TestTypes.Product> childrenDefinition =
+                filters(limits -> limits.rsql(rsql -> rsql.maxLogicalChildren(1)));
         RsqlFilterValidationException children = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification(filter,
-                        filters(limits -> limits.rsql(rsql -> rsql.maxLogicalChildren(1)))));
+                () -> guard.specification(filter, childrenDefinition));
 
         assertValidationCode(nodes, RsqlFilterValidationException.LIMIT_EXCEEDED);
         assertProtectionRule(comparisons, "filter.max-comparisons");

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -487,10 +487,11 @@ class RsqlSearchGuardTest {
                 () -> guard.specification(
                         "taxId=in=(20123456789,20987654321);taxId=in=(30123456789,30987654321)",
                         totalDefinition));
+        SearchDefinition<TestTypes.Product> lengthDefinition = filters(limits -> limits
+                .filter(filter -> filter.maxArgumentLength(5)));
         SearchProtectionException length = assertThrows(
                 SearchProtectionException.class,
-                () -> guard.specification("email==person@example.com", filters(limits -> limits
-                        .filter(filter -> filter.maxArgumentLength(5)))));
+                () -> guard.specification("email==person@example.com", lengthDefinition));
 
         assertProtectionRule(perComparison, "filter.max-arguments-per-comparison");
         assertProtectionRule(total, "filter.max-arguments-total");

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -395,8 +395,9 @@ class RsqlSearchGuardTest {
 
     @Test
     void returnsParseViolationWhenRsqlCannotBeParsed() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception =
-                assertThrows(RsqlFilterValidationException.class, () -> guard.specification("taxId==", filters()));
+                assertThrows(RsqlFilterValidationException.class, () -> guard.specification("taxId==", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.PARSE_ERROR);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -211,7 +211,8 @@ class RsqlSearchGuardTest {
 
         assertEquals("=first=", descriptor.symbol());
         assertEquals(List.of("=first=", "=second="), descriptor.symbols().stream().toList());
-        assertThrows(UnsupportedOperationException.class, () -> descriptor.symbols().clear());
+        List<String> symbols = descriptor.symbols();
+        assertThrows(UnsupportedOperationException.class, symbols::clear);
     }
 
     @Test

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -362,9 +362,10 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsAnyInvalidArgumentOfMultiValueOperators() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("taxId=in=(20123456789,123)", filters()));
+                () -> guard.specification("taxId=in=(20123456789,123)", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
         assertEquals(1, exception.errors().size());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -441,9 +441,11 @@ class RsqlSearchGuardTest {
         RsqlFilterValidationException nodes = assertThrows(
                 RsqlFilterValidationException.class,
                 () -> guard.specification(filter, nodesDefinition));
+        SearchDefinition<TestTypes.Product> comparisonsDefinition =
+                filters(limits -> limits.filter(value -> value.maxComparisons(1)));
         SearchProtectionException comparisons = assertThrows(
                 SearchProtectionException.class,
-                () -> guard.specification(filter, filters(limits -> limits.filter(value -> value.maxComparisons(1)))));
+                () -> guard.specification(filter, comparisonsDefinition));
         RsqlFilterValidationException depth = assertThrows(
                 RsqlFilterValidationException.class,
                 () -> guard.specification(filter, filters(limits -> limits.rsql(rsql -> rsql.maxDepth(1)))));

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -415,10 +415,11 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsRsqlParenthesesNestingBeforeParsing() {
+        SearchDefinition<TestTypes.Product> definition = filters(limits -> limits
+                .rsql(rsql -> rsql.maxParenthesesDepth(2)));
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("(((taxId==20123456789)))", filters(limits -> limits
-                        .rsql(rsql -> rsql.maxParenthesesDepth(2)))));
+                () -> guard.specification("(((taxId==20123456789)))", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.LIMIT_EXCEEDED);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -345,9 +345,10 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsInvalidArgumentWithTypedValidator() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("taxId==123", filters()));
+                () -> guard.specification("taxId==123", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
         RsqlValidationError error = exception.errors().get(0);

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -6,7 +6,6 @@ import io.github.ggomarighetti.searchhelper.exception.RsqlValidationError;
 import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidationException;
 import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.filter.FilterOperator;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Status;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.rsql.backend.RsqlBackendAdapter;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -211,7 +211,7 @@ class RsqlSearchGuardTest {
 
         assertEquals("=first=", descriptor.symbol());
         assertEquals(List.of("=first=", "=second="), descriptor.symbols().stream().toList());
-        List<String> symbols = descriptor.symbols();
+        Set<String> symbols = descriptor.symbols();
         assertThrows(UnsupportedOperationException.class, symbols::clear);
     }
 

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -6,7 +6,6 @@ import io.github.ggomarighetti.searchhelper.exception.RsqlValidationError;
 import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidationException;
 import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.filter.FilterOperator;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Status;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.rsql.backend.RsqlBackendAdapter;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperator;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -464,10 +464,11 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsRsqlOrBranchLimit() {
+        SearchDefinition<TestTypes.Product> definition = filters(limits -> limits
+                .filter(filter -> filter.maxOrBranches(1)));
         SearchProtectionException exception = assertThrows(
                 SearchProtectionException.class,
-                () -> guard.specification("taxId==20123456789,email==person@example.com", filters(limits -> limits
-                        .filter(filter -> filter.maxOrBranches(1)))));
+                () -> guard.specification("taxId==20123456789,email==person@example.com", definition));
 
         assertProtectionRule(exception, "filter.max-or-branches");
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -315,9 +315,10 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsUnknownField() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("passwordHash==abc", filters()));
+                () -> guard.specification("passwordHash==abc", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
         assertEquals(1, exception.errors().size());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -446,9 +446,10 @@ class RsqlSearchGuardTest {
         SearchProtectionException comparisons = assertThrows(
                 SearchProtectionException.class,
                 () -> guard.specification(filter, comparisonsDefinition));
+        SearchDefinition<TestTypes.Product> depthDefinition = filters(limits -> limits.rsql(rsql -> rsql.maxDepth(1)));
         RsqlFilterValidationException depth = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification(filter, filters(limits -> limits.rsql(rsql -> rsql.maxDepth(1)))));
+                () -> guard.specification(filter, depthDefinition));
         RsqlFilterValidationException children = assertThrows(
                 RsqlFilterValidationException.class,
                 () -> guard.specification(filter,

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -276,12 +276,11 @@ class SearchPageableGuardTest {
         SearchPageableValidationException tooManyOrders = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(tooManySorts, definition));
+        PageRequest duplicatedSort = PageRequest.of(0, 25,
+                Sort.by(Sort.Order.asc("customerName"), Sort.Order.desc("customerName")));
         SearchPageableValidationException duplicatedSelector = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(
-                        PageRequest.of(0, 25,
-                                Sort.by(Sort.Order.asc("customerName"), Sort.Order.desc("customerName"))),
-                        definition()));
+                () -> guard.pageable(duplicatedSort, definition));
         SearchPageableValidationException ignoreCase = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -203,9 +203,10 @@ class SearchPageableGuardTest {
 
         assertEquals(3, guard.pageable(PageRequest.of(3, 50), definition).getPageNumber());
 
+        PageRequest invalidPage = PageRequest.of(4, 50);
         SearchPageableValidationException pageException = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(4, 50), definition));
+                () -> guard.pageable(invalidPage, definition));
         SearchPageableValidationException sizeException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(PageRequest.of(0, 101), definition));

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -207,9 +207,10 @@ class SearchPageableGuardTest {
         SearchPageableValidationException pageException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(invalidPage, definition));
+        PageRequest invalidSize = PageRequest.of(0, 101);
         SearchPageableValidationException sizeException = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(0, 101), definition));
+                () -> guard.pageable(invalidSize, definition));
 
         assertValidationCode(pageException, SearchPageableValidationException.PAGE_RULES_FORBIDDEN);
         assertValidationCode(sizeException, SearchPageableValidationException.PAGE_RULES_FORBIDDEN);

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -229,9 +229,10 @@ class SearchPageableGuardTest {
         SearchPageableValidationException pageException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(invalidPage, definition));
+        PageRequest invalidSize = PageRequest.of(0, 101);
         SearchPageableValidationException sizeException = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(0, 101), definition()));
+                () -> guard.pageable(invalidSize, definition));
         SearchPageableValidationException offsetException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(PageRequest.of(100, 101), definition(SearchPolicy.builder()

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -285,11 +285,10 @@ class SearchPageableGuardTest {
         SearchPageableValidationException ignoreCase = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(ignoreCaseSort, definition));
+        PageRequest nullHandlingSort = PageRequest.of(0, 25, Sort.by(Sort.Order.asc("amount").nullsLast()));
         SearchPageableValidationException nullHandling = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(
-                        PageRequest.of(0, 25, Sort.by(Sort.Order.asc("amount").nullsLast())),
-                        definition()));
+                () -> guard.pageable(nullHandlingSort, definition));
 
         assertValidationCode(tooManyOrders, SearchPageableValidationException.SORT_LIMIT_EXCEEDED);
         assertValidationCode(duplicatedSelector, SearchPageableValidationException.SORT_LIMIT_EXCEEDED);

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -161,10 +161,11 @@ class SearchPageableGuardTest {
                 .fields(fields -> fields.add("email", String.class))
                 .paging()
                 .build();
+        PageRequest pageRequest = PageRequest.of(0, 25, Sort.by("email"));
 
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(0, 25, Sort.by("email")), definition));
+                () -> guard.pageable(pageRequest, definition));
 
         assertValidationCode(exception, SearchPageableValidationException.SORT_RULES_FORBIDDEN);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -218,7 +218,8 @@ class SearchPageableGuardTest {
         assertTrue(pageException.violations().get(0).constraint().endsWith(".Max"));
         assertEquals("size", sizeException.violations().get(0).path());
         assertTrue(sizeException.violations().get(0).constraint().endsWith(".Max"));
-        assertThrows(UnsupportedOperationException.class, () -> pageException.violations().clear());
+        var violations = pageException.violations();
+        assertThrows(UnsupportedOperationException.class, violations::clear);
     }
 
     @Test

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -132,12 +132,12 @@ class SearchPageableGuardTest {
 
     @Test
     void rejectsUnpagedLimitAboveConfiguredMaximum() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchPolicy.builder()
-                        .paging(paging -> paging
-                                .maxUnpagedSize(10)
-                                .unpagedSize(11))
-                        .build());
+        var builder = SearchPolicy.builder()
+                .paging(paging -> paging
+                        .maxUnpagedSize(10)
+                        .unpagedSize(11));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertEquals(
                 "paging.defaultUnpagedSize must be less than or equal to paging.maxUnpagedSize",

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -104,9 +104,11 @@ class SearchPageableGuardTest {
 
     @Test
     void rejectsUnpagedPageableByDefault() {
+        Pageable pageable = Pageable.unpaged();
+        SearchDefinition<TestTypes.Product> definition = definition();
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(Pageable.unpaged(), definition()));
+                () -> guard.pageable(pageable, definition));
 
         assertValidationCode(exception, SearchPageableValidationException.PAGE_LIMIT_EXCEEDED);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -146,9 +146,11 @@ class SearchPageableGuardTest {
 
     @Test
     void rejectsUnknownSortSelector() {
+        PageRequest pageRequest = PageRequest.of(0, 25, Sort.by("passwordHash"));
+        SearchDefinition<TestTypes.Product> definition = definition();
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(0, 25, Sort.by("passwordHash")), definition()));
+                () -> guard.pageable(pageRequest, definition));
 
         assertValidationCode(exception, SearchPageableValidationException.SORT_RULES_FORBIDDEN);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -172,9 +172,11 @@ class SearchPageableGuardTest {
 
     @Test
     void rejectsSortDirectionThatIsNotAllowed() {
+        PageRequest pageRequest = PageRequest.of(0, 25, Sort.by(Sort.Order.asc("createdAt")));
+        SearchDefinition<TestTypes.Product> definition = definition();
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(0, 25, Sort.by(Sort.Order.asc("createdAt"))), definition()));
+                () -> guard.pageable(pageRequest, definition));
 
         assertValidationCode(exception, SearchPageableValidationException.SORT_RULES_FORBIDDEN);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -262,9 +262,10 @@ class SearchPageableGuardTest {
         assertTrue(boundedUnpaged.isPaged());
         assertEquals(40, boundedUnpaged.getPageSize());
 
+        PageRequest oversizedPage = PageRequest.of(0, 6);
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> limitedGuard.pageable(PageRequest.of(0, 6), definition));
+                () -> limitedGuard.pageable(oversizedPage, definition));
         assertValidationCode(exception, SearchPageableValidationException.PAGE_LIMIT_EXCEEDED);
     }
 

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -271,11 +271,11 @@ class SearchPageableGuardTest {
 
     @Test
     void rejectsSortSafetyLimits() {
+        SearchDefinition<TestTypes.Product> definition = definition();
+        PageRequest tooManySorts = PageRequest.of(0, 25, Sort.by("customerName", "amount", "createdAt", "email"));
         SearchPageableValidationException tooManyOrders = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(
-                        PageRequest.of(0, 25, Sort.by("customerName", "amount", "createdAt", "email")),
-                        definition()));
+                () -> guard.pageable(tooManySorts, definition));
         SearchPageableValidationException duplicatedSelector = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -186,10 +186,11 @@ class SearchPageableGuardTest {
         SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder().entity(TestTypes.Product.class)
                 .fields(fields -> fields.add("email", String.class).sortable())
                 .build();
+        PageRequest pageRequest = PageRequest.of(0, 25);
 
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(0, 25), definition));
+                () -> guard.pageable(pageRequest, definition));
 
         assertValidationCode(exception, SearchPageableValidationException.PAGE_RULES_FORBIDDEN);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -14,7 +14,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.data.domain.Sort.Direction.ASC;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -281,11 +281,10 @@ class SearchPageableGuardTest {
         SearchPageableValidationException duplicatedSelector = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(duplicatedSort, definition));
+        PageRequest ignoreCaseSort = PageRequest.of(0, 25, Sort.by(Sort.Order.asc("amount").ignoreCase()));
         SearchPageableValidationException ignoreCase = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(
-                        PageRequest.of(0, 25, Sort.by(Sort.Order.asc("amount").ignoreCase())),
-                        definition()));
+                () -> guard.pageable(ignoreCaseSort, definition));
         SearchPageableValidationException nullHandling = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -2,7 +2,6 @@ package io.github.ggomarighetti.searchhelper.compile;
 
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.exception.SearchPageableValidationException;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.unit.TestTypes;
 import java.math.BigDecimal;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -224,9 +224,11 @@ class SearchPageableGuardTest {
 
     @Test
     void rejectsPageableSafetyLimitsBeforeHibernateRules() {
+        SearchDefinition<TestTypes.Product> definition = definition();
+        PageRequest invalidPage = PageRequest.of(101, 1);
         SearchPageableValidationException pageException = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(101, 1), definition()));
+                () -> guard.pageable(invalidPage, definition));
         SearchPageableValidationException sizeException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(PageRequest.of(0, 101), definition()));

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -75,13 +75,12 @@ class SearchPageableGuardTest {
     @Test
     void rejectsDifferentSortSelectorsThatResolveToSameInternalPath() {
         SearchDefinition<TestTypes.Product> definition = duplicateSortPathDefinition();
+        PageRequest pageRequest = PageRequest.of(0, 25,
+                Sort.by(Sort.Order.asc("legacyAmount"), Sort.Order.desc("amount")));
 
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(
-                        PageRequest.of(0, 25,
-                                Sort.by(Sort.Order.asc("legacyAmount"), Sort.Order.desc("amount"))),
-                        definition));
+                () -> guard.pageable(pageRequest, definition));
 
         assertValidationCode(exception, SearchPageableValidationException.SORT_LIMIT_EXCEEDED);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -233,11 +233,14 @@ class SearchPageableGuardTest {
         SearchPageableValidationException sizeException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(invalidSize, definition));
+        SearchPolicy offsetPolicy = SearchPolicy.builder()
+                .paging(paging -> paging.maxPage(200).maxSize(200))
+                .build();
+        SearchDefinition<TestTypes.Product> offsetDefinition = definition(offsetPolicy);
+        PageRequest offsetPage = PageRequest.of(100, 101);
         SearchPageableValidationException offsetException = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(100, 101), definition(SearchPolicy.builder()
-                        .paging(paging -> paging.maxPage(200).maxSize(200))
-                        .build())));
+                () -> guard.pageable(offsetPage, offsetDefinition));
 
         assertValidationCode(pageException, SearchPageableValidationException.PAGE_LIMIT_EXCEEDED);
         assertValidationCode(sizeException, SearchPageableValidationException.PAGE_LIMIT_EXCEEDED);

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
@@ -111,19 +111,23 @@ class SearchProtectionTest {
                 .orElseThrow();
 
         SearchProtectionContext protection = new SearchProtectionContext(policy, SearchCompilationMode.PAGE);
+        var nameField = definition.field("name").orElseThrow();
+        List<String> escapedArguments = List.of("abc\\*");
         assertDoesNotThrow(() -> protection.recordComparison(
-                definition.field("name").orElseThrow(),
+                nameField,
                 descriptor,
                 1,
-                List.of("abc\\*")));
+                escapedArguments));
 
+        SearchProtectionContext wildcardProtection = new SearchProtectionContext(policy, SearchCompilationMode.PAGE);
+        List<String> wildcardArguments = List.of("abc*");
         SearchProtectionException exception = assertThrows(
                 SearchProtectionException.class,
-                () -> new SearchProtectionContext(policy, SearchCompilationMode.PAGE).recordComparison(
-                        definition.field("name").orElseThrow(),
+                () -> wildcardProtection.recordComparison(
+                        nameField,
                         descriptor,
                         1,
-                        List.of("abc*")));
+                        wildcardArguments));
 
         assertRule(exception, "filter.like.allow-trailing-wildcard", 1, 0);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
@@ -146,19 +146,20 @@ class SearchProtectionTest {
                 .paging()
                 .build();
 
+        PageRequest pageRequest = PageRequest.of(0, 10);
         SearchProtectionException pageException = assertThrows(
                 SearchProtectionException.class,
                 () -> compiler.compile(
                         "reviewRating==5",
                         null,
-                        PageRequest.of(0, 10),
+                        pageRequest,
                         definition));
 
         assertRule(pageException, "paging.page.allow-to-many-count", 1, 0);
         assertDoesNotThrow(() -> compiler.compileSlice(
                 "reviewRating==5",
                 null,
-                PageRequest.of(0, 10),
+                pageRequest,
                 definition));
     }
 

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
@@ -195,11 +195,10 @@ class SearchProtectionTest {
                 .paging()
                 .build();
 
+        PageRequest pageRequest = PageRequest.of(0, 25, Sort.by("supplierName"));
         SearchProtectionException exception = assertThrows(
                 SearchProtectionException.class,
-                () -> guard.pageable(
-                        PageRequest.of(0, 25, Sort.by("supplierName")),
-                        definition));
+                () -> guard.pageable(pageRequest, definition));
 
         assertRule(exception, "sorting.allow-relation-sorting", 1, 0);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
@@ -215,9 +215,10 @@ class SearchProtectionTest {
                 .query(query -> query.specification(term -> Specification.unrestricted()))
                 .build();
 
+        Pageable pageable = Pageable.unpaged();
         SearchProtectionException exception = assertThrows(
                 SearchProtectionException.class,
-                () -> compiler.compile(null, "tablet", Pageable.unpaged(), definition));
+                () -> compiler.compile(null, "tablet", pageable, definition));
 
         assertRule(exception, "query.allow-with-unpaged", 1, 0);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
@@ -3,7 +3,6 @@ package io.github.ggomarighetti.searchhelper.compile;
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.exception.SearchQueryValidationException;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.unit.TestTypes;
 import java.util.concurrent.atomic.AtomicReference;
 import org.hibernate.validator.cfg.defs.PatternDef;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
@@ -24,9 +24,10 @@ class SearchQueryGuardTest {
 
     @Test
     void rejectsQueryWhenDefinitionDoesNotDeclareQuery() {
+        SearchDefinition<TestTypes.Product> definition = definitionWithoutQuery();
         SearchQueryValidationException exception = assertThrows(
                 SearchQueryValidationException.class,
-                () -> guard.specification("tablets", definitionWithoutQuery()));
+                () -> guard.specification("tablets", definition));
 
         assertValidationCode(exception, SearchQueryValidationException.QUERY_RULES_FORBIDDEN);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
@@ -85,7 +85,8 @@ class SearchQueryGuardTest {
         assertEquals(
                 "{jakarta.validation.constraints.Pattern.message}",
                 patternException.violations().get(0).messageTemplate());
-        assertThrows(UnsupportedOperationException.class, () -> sizeException.violations().clear());
+        var violations = sizeException.violations();
+        assertThrows(UnsupportedOperationException.class, violations::clear);
     }
 
     @Test

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchFixtures.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchFixtures.java
@@ -3,7 +3,6 @@ package io.github.ggomarighetti.searchhelper.integration;
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSpecifications;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
-import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -233,12 +233,13 @@ class ProductSearchPostgresIT {
         assertRsqlCode("status==PUBLISHED", definition, RsqlFilterValidationException.RULES_FORBIDDEN);
         assertRsqlCode("publicId==not-a-uuid", definition, RsqlFilterValidationException.RULES_FORBIDDEN);
 
+        PageRequest unsafeSort = PageRequest.of(0, 10, Sort.by("internalCost"));
         SearchPageableValidationException sortException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> compiler.compile(
                         null,
                         null,
-                        PageRequest.of(0, 10, Sort.by("internalCost")),
+                        unsafeSort,
                         definition));
         SearchPageableValidationException pageException = assertThrows(
                 SearchPageableValidationException.class,

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -265,10 +265,11 @@ class ProductSearchPostgresIT {
                 .fields(fields -> fields.add("displayName", String.class)
                         .filterable(filter -> filter.allow(EQUAL)))
                 .build();
+        JpaSearchDefinitionValidator validator = jpaDefinitionValidator();
 
         SearchDefinitionValidationException exception = assertThrows(
                 SearchDefinitionValidationException.class,
-                () -> jpaDefinitionValidator().validate(definition));
+                () -> validator.validate(definition));
 
         assertEquals(SearchDefinitionValidationException.JPA_PATH_UNRESOLVED, exception.code());
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -241,12 +241,13 @@ class ProductSearchPostgresIT {
                         null,
                         unsafeSort,
                         definition));
+        PageRequest unsafePage = PageRequest.of(0, 51);
         SearchPageableValidationException pageException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> compiler.compile(
                         null,
                         null,
-                        PageRequest.of(0, 51),
+                        unsafePage,
                         definition));
 
         assertEquals(SearchPageableValidationException.SORT_RULES_FORBIDDEN, sortException.code());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -40,7 +40,6 @@ import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.E
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @DataJpaTest(
         showSql = false,

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -294,9 +294,10 @@ class ProductSearchPostgresIT {
             String filter,
             SearchDefinition<Product> definition,
             String expectedCode) {
+        PageRequest pageRequest = PageRequest.of(0, 1);
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> compiler.compile(filter, null, PageRequest.of(0, 1), definition));
+                () -> compiler.compile(filter, null, pageRequest, definition));
 
         assertEquals(expectedCode, exception.code());
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -40,7 +40,6 @@ import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.E
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.springframework.data.domain.Sort.Direction.ASC;
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @DataJpaTest(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -8,7 +8,6 @@ import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidation
 import io.github.ggomarighetti.searchhelper.exception.SearchPageableValidationException;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductRepository;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSeeder.Catalog;
-import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSpecifications;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.integration.postgres.PostgresTestEnvironment;
 import io.github.ggomarighetti.searchhelper.jpa.JpaSearchDefinitionValidator;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -19,7 +19,6 @@ import org.springframework.boot.convert.ApplicationConversionService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -7,7 +7,6 @@ import io.github.ggomarighetti.searchhelper.exception.RsqlFilterValidationExcept
 import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidationException;
 import io.github.ggomarighetti.searchhelper.exception.SearchPageableValidationException;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductRepository;
-import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSeeder;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSeeder.Catalog;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSpecifications;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
-import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -30,7 +30,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresPlanIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresPlanIT.java
@@ -5,7 +5,6 @@ import io.github.ggomarighetti.searchhelper.compile.CompiledSearch;
 import io.github.ggomarighetti.searchhelper.compile.SearchCompiler;
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductRepository;
-import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSpecifications;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.integration.postgres.PostgresExplain;
 import io.github.ggomarighetti.searchhelper.integration.postgres.PostgresPlan;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/SearchDefinitionRuntimeValidationPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/SearchDefinitionRuntimeValidationPostgresIT.java
@@ -57,11 +57,12 @@ class SearchDefinitionRuntimeValidationPostgresIT {
                 .run(context -> {
                     SearchCompiler compiler = context.getBean(SearchCompiler.class);
                     SearchDefinition<?> definition = context.getBean(SearchDefinition.class);
+                    PageRequest pageRequest = PageRequest.of(0, 20);
 
                     assertThatThrownBy(() -> compiler.compile(
                                     "displayName==Laptop",
                                     null,
-                                    PageRequest.of(0, 20),
+                                    pageRequest,
                                     definition))
                             .isInstanceOf(SearchDefinitionValidationException.class)
                             .hasMessageContaining("displayName")

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/SearchDefinitionRuntimeValidationPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/SearchDefinitionRuntimeValidationPostgresIT.java
@@ -78,11 +78,12 @@ class SearchDefinitionRuntimeValidationPostgresIT {
                 .run(context -> {
                     SearchCompiler compiler = context.getBean(SearchCompiler.class);
                     SearchDefinition<?> definition = context.getBean(SearchDefinition.class);
+                    PageRequest pageRequest = PageRequest.of(0, 20);
 
                     assertThatThrownBy(() -> compiler.compile(
                                     null,
                                     null,
-                                    PageRequest.of(0, 20),
+                                    pageRequest,
                                     definition))
                             .isInstanceOf(SearchDefinitionValidationException.class)
                             .hasMessageContaining("displayName")

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
@@ -1,6 +1,5 @@
 package io.github.ggomarighetti.searchhelper.integration.postgres;
 
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Category;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Review;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Supplier;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
@@ -1,6 +1,5 @@
 package io.github.ggomarighetti.searchhelper.integration.postgres;
 
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Review;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Supplier;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
@@ -1,6 +1,5 @@
 package io.github.ggomarighetti.searchhelper.integration.postgres;
 
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Supplier;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.sql.PreparedStatement;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
@@ -1,6 +1,5 @@
 package io.github.ggomarighetti.searchhelper.integration.postgres;
 
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Review;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Supplier;
 import java.math.BigDecimal;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/property/SearchPropertyFixtures.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/property/SearchPropertyFixtures.java
@@ -15,6 +15,7 @@ import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Status;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
+import io.github.ggomarighetti.searchhelper.sort.SearchSorting;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Map;
@@ -120,7 +121,7 @@ public final class SearchPropertyFixtures {
                             .sortable(sort -> sort.allow(Sort.Direction.DESC));
                     fields.add("supplierName", String.class)
                             .path("supplier.name")
-                            .sortable(sort -> sort.allowIgnoreCase());
+                            .sortable(SearchSorting.Builder::allowIgnoreCase);
                     fields.add("status", Status.class);
                 })
                 .paging()

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
@@ -107,13 +107,14 @@ class DefaultFilterOperatorsTest {
 
     @Test
     void filteringWithDefaultsCannotDenyTheEntireProfile() {
+        var builder = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("active", Boolean.class)
+                        .filterable(filter -> filter.withDefaults().deny(EQUAL, NOT_EQUAL)));
+
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
-                () -> SearchDefinition.builder()
-                        .entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("active", Boolean.class)
-                                .filterable(filter -> filter.withDefaults().deny(EQUAL, NOT_EQUAL)))
-                        .build());
+                builder::build);
 
         assertEquals(
                 "selector 'active' filtering must declare at least one allowed operator",

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
@@ -152,12 +152,13 @@ class DefaultFilterOperatorsTest {
 
     @Test
     void reportsUnsupportedDefaultProfilesAsDefinitionErrors() {
+        var builder = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("owner", TestTypes.Owner.class).filterable());
+
         SearchDefinitionValidationException exception = assertThrows(
                 SearchDefinitionValidationException.class,
-                () -> SearchDefinition.builder()
-                        .entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("owner", TestTypes.Owner.class).filterable())
-                        .build());
+                builder::build);
 
         assertEquals(
                 SearchDefinitionValidationException.DEFAULT_OPERATORS_UNSUPPORTED_TYPE,

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
@@ -182,7 +182,7 @@ class DefaultFilterOperatorsTest {
     void returnedProfilesAreImmutable() {
         Set<RsqlOperator> operators = DefaultFilterOperators.forType(String.class);
 
-        assertThrows(UnsupportedOperationException.class, () -> operators.clear());
+        assertThrows(UnsupportedOperationException.class, operators::clear);
     }
 
     private static void assertContains(Class<?> type, RsqlOperator... expected) {

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
@@ -167,13 +167,14 @@ class DefaultFilterOperatorsTest {
 
     @Test
     void filteringWithDefaultsReportsUnsupportedProfilesAsDefinitionErrors() {
+        var builder = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("owner", TestTypes.Owner.class)
+                        .filterable(filter -> filter.withDefaults().allow(IS_NULL)));
+
         SearchDefinitionValidationException exception = assertThrows(
                 SearchDefinitionValidationException.class,
-                () -> SearchDefinition.builder()
-                        .entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("owner", TestTypes.Owner.class)
-                                .filterable(filter -> filter.withDefaults().allow(IS_NULL)))
-                        .build());
+                builder::build);
 
         assertEquals(
                 SearchDefinitionValidationException.DEFAULT_OPERATORS_UNSUPPORTED_TYPE,

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -197,14 +197,16 @@ class SearchCompilerTest {
                         .conversionService(ApplicationConversionService.getSharedInstance())
                         .build(),
                 policy);
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        SearchDefinition<TestTypes.Product> definition = definition(new AtomicReference<>());
 
         assertThrows(
                 SearchProtectionException.class,
                 () -> customCompiler.compile(
                         "taxId=in=(1,2)",
                         null,
-                        PageRequest.of(0, 10),
-                definition(new AtomicReference<>())));
+                        pageRequest,
+                        definition));
     }
 
     @Test

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -5,7 +5,6 @@ import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.compile.CompiledSearch;
 import io.github.ggomarighetti.searchhelper.compile.SearchCompiler;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
-import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
 import io.github.ggomarighetti.searchhelper.rsql.SearchRsqlEngine;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Predicate;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -139,8 +139,8 @@ class SearchCompilerTest {
                 () -> compiler.compile(
                         null,
                         null,
-                        PageRequest.of(0, 10),
-                        emptyDefinition(),
+                        pageRequest,
+                        definition,
                         (Specification<TestTypes.Product>) null));
 
         assertEquals("specifications must not be null", arrayException.getMessage());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -243,7 +243,7 @@ class SearchCompilerTest {
                 () -> customCompiler.compile(null, null, pageRequest, definition));
         assertThrows(
                 IllegalStateException.class,
-                () -> customCompiler.compile(null, null, PageRequest.of(0, 10), definition));
+                () -> customCompiler.compile(null, null, pageRequest, definition));
 
         assertEquals(2, validations.get());
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -236,10 +236,11 @@ class SearchCompilerTest {
                     throw new IllegalStateException("invalid definition");
                 }));
         SearchDefinition<TestTypes.Product> definition = emptyDefinition();
+        PageRequest pageRequest = PageRequest.of(0, 10);
 
         assertThrows(
                 IllegalStateException.class,
-                () -> customCompiler.compile(null, null, PageRequest.of(0, 10), definition));
+                () -> customCompiler.compile(null, null, pageRequest, definition));
         assertThrows(
                 IllegalStateException.class,
                 () -> customCompiler.compile(null, null, PageRequest.of(0, 10), definition));

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -128,10 +128,12 @@ class SearchCompilerTest {
     void rejectsNullApplicationSpecifications() {
         @SuppressWarnings("unchecked")
         Specification<TestTypes.Product>[] nullSpecifications = null;
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        SearchDefinition<TestTypes.Product> definition = emptyDefinition();
 
         NullPointerException arrayException = assertThrows(
                 NullPointerException.class,
-                () -> compiler.compile(null, null, PageRequest.of(0, 10), emptyDefinition(), nullSpecifications));
+                () -> compiler.compile(null, null, pageRequest, definition, nullSpecifications));
         NullPointerException elementException = assertThrows(
                 NullPointerException.class,
                 () -> compiler.compile(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -4,7 +4,6 @@ import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.compile.CompiledSearch;
 import io.github.ggomarighetti.searchhelper.compile.SearchCompiler;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
 import io.github.ggomarighetti.searchhelper.rsql.SearchRsqlEngine;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -506,12 +506,13 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsPathDeeperThanSafetyLimitByDefault() {
-        SearchDefinitionValidationException exception = assertThrows(SearchDefinitionValidationException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("countryCode", String.class)
-                                .path("customer.region.country.code")
-                                .sortable())
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("countryCode", String.class)
+                        .path("customer.region.country.code")
+                        .sortable());
+
+        SearchDefinitionValidationException exception =
+                assertThrows(SearchDefinitionValidationException.class, builder::build);
 
         assertEquals(SearchDefinitionValidationException.PATH_LIMIT_EXCEEDED, exception.code());
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -6,7 +6,6 @@ import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidation
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.query.SearchQuery;
-import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
 import io.github.ggomarighetti.searchhelper.sort.SearchSorting;
 import java.math.BigDecimal;
 import java.util.Set;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -542,12 +542,12 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsNestedCollectionValuedPathWhenElementTypeCannotBeResolved() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("reviewRating", Integer.class)
-                                .path("rawReviews.rating")
-                                .filterable(filter -> filter.allow(EQUAL)))
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("reviewRating", Integer.class)
+                        .path("rawReviews.rating")
+                        .filterable(filter -> filter.allow(EQUAL)));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertTrue(exception.getMessage().contains("could not be resolved"));
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -71,12 +71,11 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsSubtypeOutsideEntityHierarchy() {
-        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
-                .fields(fields -> fields.add("expiresAt", java.time.Instant.class)
-                        .subtype(String.class)
-                        .filterable(filter -> filter.allow(EQUAL)));
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class);
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> addInvalidSubtypeField(builder));
 
         assertTrue(exception.getMessage().contains("must extend entity"));
     }
@@ -574,5 +573,11 @@ class SearchDefinitionTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertTrue(exception.getMessage().contains("ignoreCase sorting requires a CharSequence path"));
+    }
+
+    private static void addInvalidSubtypeField(SearchDefinition.Builder<TestTypes.Product> builder) {
+        builder.fields(fields -> fields.add("expiresAt", java.time.Instant.class)
+                .subtype(String.class)
+                .filterable(filter -> filter.allow(EQUAL)));
     }
 }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -392,15 +392,16 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsDuplicatedQueryDeclaration() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("email", String.class))
-                        .query(query -> query.specification(term ->
-                                (root, criteria, builder) -> builder.conjunction()))
-                        .query(SearchQuery.<TestTypes.Product>builder()
-                                .specification(term -> (root, criteria, builder) -> builder.conjunction())
-                                .build())
-                        .build());
+        SearchQuery<TestTypes.Product> query = SearchQuery.<TestTypes.Product>builder()
+                .specification(term -> (root, criteria, builder) -> builder.conjunction())
+                .build();
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class))
+                .query(definitionQuery -> definitionQuery.specification(term ->
+                        (root, criteria, criteriaBuilder) -> criteriaBuilder.conjunction()))
+                .query(query);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertEquals("query is already declared", exception.getMessage());
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -397,10 +397,11 @@ class SearchDefinitionTest {
         var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
                 .fields(fields -> fields.add("email", String.class))
                 .query(definitionQuery -> definitionQuery.specification(term ->
-                        (root, criteria, criteriaBuilder) -> criteriaBuilder.conjunction()))
-                .query(query);
+                        (root, criteria, criteriaBuilder) -> criteriaBuilder.conjunction()));
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> declareDuplicateQuery(builder, query));
 
         assertEquals("query is already declared", exception.getMessage());
     }
@@ -579,5 +580,11 @@ class SearchDefinitionTest {
         builder.fields(fields -> fields.add("expiresAt", java.time.Instant.class)
                 .subtype(String.class)
                 .filterable(filter -> filter.allow(EQUAL)));
+    }
+
+    private static void declareDuplicateQuery(
+            SearchDefinition.Builder<TestTypes.Product> builder,
+            SearchQuery<TestTypes.Product> query) {
+        builder.query(query);
     }
 }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -566,12 +566,12 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsIgnoreCaseSortingForNonTextPaths() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("amount", BigDecimal.class)
-                                .path("price")
-                                .sortable(SearchSorting.Builder::allowIgnoreCase))
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("amount", BigDecimal.class)
+                        .path("price")
+                        .sortable(SearchSorting.Builder::allowIgnoreCase));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertTrue(exception.getMessage().contains("ignoreCase sorting requires a CharSequence path"));
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -554,12 +554,12 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsSortingThroughCollectionValuedPath() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("reviewRating", Integer.class)
-                                .path("reviews.rating")
-                                .sortable())
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("reviewRating", Integer.class)
+                        .path("reviews.rating")
+                        .sortable());
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertTrue(exception.getMessage().contains("must not traverse collection-valued paths"));
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -480,12 +480,12 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsFieldTypeThatDoesNotMatchEntityPath() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("amount", String.class)
-                                .path("price")
-                                .filterable(filter -> filter.allow(EQUAL)))
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("amount", String.class)
+                        .path("price")
+                        .filterable(filter -> filter.allow(EQUAL)));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertEquals(
                 "selector 'amount' path 'price' resolves to type 'java.math.BigDecimal' but was declared as 'java.lang.String'",

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -71,12 +71,12 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsSubtypeOutsideEntityHierarchy() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("expiresAt", java.time.Instant.class)
-                                .subtype(String.class)
-                                .filterable(filter -> filter.allow(EQUAL)))
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("expiresAt", java.time.Instant.class)
+                        .subtype(String.class)
+                        .filterable(filter -> filter.allow(EQUAL)));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertTrue(exception.getMessage().contains("must extend entity"));
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -494,12 +494,12 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsFilteringWithoutAllowedOperators() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("taxId", String.class)
-                                .path("person.taxIdentifier")
-                                .filterable(filter -> {}))
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("taxId", String.class)
+                        .path("person.taxIdentifier")
+                        .filterable(filter -> {}));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertEquals("selector 'taxId' filtering must declare at least one allowed operator", exception.getMessage());
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -7,6 +7,7 @@ import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.query.SearchQuery;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
+import io.github.ggomarighetti.searchhelper.sort.SearchSorting;
 import java.math.BigDecimal;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -568,7 +569,7 @@ class SearchDefinitionTest {
                 SearchDefinition.builder().entity(TestTypes.Product.class)
                         .fields(fields -> fields.add("amount", BigDecimal.class)
                                 .path("price")
-                                .sortable(sort -> sort.allowIgnoreCase()))
+                                .sortable(SearchSorting.Builder::allowIgnoreCase))
                         .build());
 
         assertTrue(exception.getMessage().contains("ignoreCase sorting requires a CharSequence path"));

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -464,7 +464,7 @@ class SearchDefinitionTest {
         Set<?> operators = definition.filteringOperators();
 
         assertEquals(Set.of(EQUAL, IN), operators);
-        assertThrows(UnsupportedOperationException.class, () -> definition.filteringOperators().clear());
+        assertThrows(UnsupportedOperationException.class, operators::clear);
     }
 
     @Test


### PR DESCRIPTION
### Resume
Removes redundant record constructor assignments while preserving validation behavior.
Refactors exception assertions to isolate the single operation expected to throw.
Cleans unused imports, simplifies method references, removes legacy date defaults, and types the RSQL JPA predicate context as a record.
Keeps fixes split into individual commits for reviewability.

### Evidence
> Not required

### Reference
> Not required