### PR TITLE
test: expand coverage and harden CI verification

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -66,7 +66,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f
         with:
           use_oidc: true
           files: target/site/jacoco/jacoco.xml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f
         with:
           use_oidc: true
           files: target/surefire-reports/*.xml,target/failsafe-reports/*.xml

--- a/src/main/java/io/github/ggomarighetti/searchhelper/definition/SearchDefinitionFactory.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/definition/SearchDefinitionFactory.java
@@ -11,7 +11,7 @@ public record SearchDefinitionFactory(SearchPolicy policy) {
      * @param policy application-wide policy
      */
     public SearchDefinitionFactory {
-        policy = Objects.requireNonNull(policy, "policy must not be null");
+        Objects.requireNonNull(policy, "policy must not be null");
     }
 
     /**

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlValidationError.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlValidationError.java
@@ -40,7 +40,7 @@ public record RsqlValidationError(
     public RsqlValidationError {
         requireText(code, "code");
         requireText(astPath, "astPath");
-        message = requireText(message, "message");
+        requireText(message, "message");
         if (argumentIndex != null && argumentIndex < 0) {
             throw new IllegalArgumentException("argumentIndex must not be negative");
         }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlValidationError.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlValidationError.java
@@ -39,7 +39,7 @@ public record RsqlValidationError(
     /** Validates required location and message fields. */
     public RsqlValidationError {
         requireText(code, "code");
-        astPath = requireText(astPath, "astPath");
+        requireText(astPath, "astPath");
         message = requireText(message, "message");
         if (argumentIndex != null && argumentIndex < 0) {
             throw new IllegalArgumentException("argumentIndex must not be negative");

--- a/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlValidationError.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/exception/RsqlValidationError.java
@@ -38,7 +38,7 @@ public record RsqlValidationError(
 
     /** Validates required location and message fields. */
     public RsqlValidationError {
-        code = requireText(code, "code");
+        requireText(code, "code");
         astPath = requireText(astPath, "astPath");
         message = requireText(message, "message");
         if (argumentIndex != null && argumentIndex < 0) {

--- a/src/main/java/io/github/ggomarighetti/searchhelper/filter/DefaultFilterOperators.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/filter/DefaultFilterOperators.java
@@ -21,9 +21,7 @@ import java.time.YearMonth;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.Calendar;
 import java.util.Currency;
-import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Objects;
@@ -101,8 +99,6 @@ public final class DefaultFilterOperators {
             Double.class,
             BigInteger.class,
             BigDecimal.class,
-            Date.class,
-            Calendar.class,
             Instant.class,
             LocalDate.class,
             LocalDateTime.class,

--- a/src/main/java/io/github/ggomarighetti/searchhelper/filter/FilterValidationError.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/filter/FilterValidationError.java
@@ -20,7 +20,7 @@ public record FilterValidationError(
         RuleViolation violation) {
     /** Validates the fields required by the selected error code. */
     public FilterValidationError {
-        code = Objects.requireNonNull(code, "code must not be null");
+        Objects.requireNonNull(code, "code must not be null");
         if (argumentIndex != null && argumentIndex < 0) {
             throw new IllegalArgumentException("argumentIndex must not be negative");
         }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/policy/SearchPolicy.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/policy/SearchPolicy.java
@@ -961,7 +961,7 @@ public final class SearchPolicy {
             requirePositive(defaultUnpagedSize, "paging.defaultUnpagedSize");
             requirePositive(maxUnpagedSize, "paging.maxUnpagedSize");
             Objects.requireNonNull(page, "paging.page must not be null");
-            slice = Objects.requireNonNull(slice, "paging.slice must not be null");
+            Objects.requireNonNull(slice, "paging.slice must not be null");
             if (maxPage < minPage) {
                 throw new IllegalArgumentException("paging.maxPage must be greater than or equal to paging.minPage");
             }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/policy/SearchPolicy.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/policy/SearchPolicy.java
@@ -481,7 +481,7 @@ public final class SearchPolicy {
             requireNonNegative(maxHeterogeneousOrBranches, "filter.maxHeterogeneousOrBranches");
             requireNonNegative(maxJoinedPaths, "filter.maxJoinedPaths");
             requireNonNegative(maxToManyPaths, "filter.maxToManyPaths");
-            like = Objects.requireNonNull(like, "filter.like must not be null");
+            Objects.requireNonNull(like, "filter.like must not be null");
         }
 
         /**

--- a/src/main/java/io/github/ggomarighetti/searchhelper/policy/SearchPolicy.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/policy/SearchPolicy.java
@@ -960,7 +960,7 @@ public final class SearchPolicy {
             requireNonNegative(maxOffset, "paging.maxOffset");
             requirePositive(defaultUnpagedSize, "paging.defaultUnpagedSize");
             requirePositive(maxUnpagedSize, "paging.maxUnpagedSize");
-            page = Objects.requireNonNull(page, "paging.page must not be null");
+            Objects.requireNonNull(page, "paging.page must not be null");
             slice = Objects.requireNonNull(slice, "paging.slice must not be null");
             if (maxPage < minPage) {
                 throw new IllegalArgumentException("paging.maxPage must be greater than or equal to paging.minPage");

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlComparison.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlComparison.java
@@ -16,7 +16,7 @@ public record RsqlComparison(String selector, RsqlOperator operator, List<String
     /** Validates and snapshots comparison data. */
     public RsqlComparison {
         Assert.hasText(selector, "selector must not be blank");
-        operator = Objects.requireNonNull(operator, "operator must not be null");
+        Objects.requireNonNull(operator, "operator must not be null");
         arguments = List.copyOf(Objects.requireNonNull(arguments, "arguments must not be null"));
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
@@ -30,6 +30,6 @@ public record RsqlCompilationRequest<T>(
         Objects.requireNonNull(ast, "ast must not be null");
         Objects.requireNonNull(definition, "definition must not be null");
         Objects.requireNonNull(conversionService, "conversionService must not be null");
-        operators = Objects.requireNonNull(operators, "operators must not be null");
+        Objects.requireNonNull(operators, "operators must not be null");
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
@@ -29,7 +29,7 @@ public record RsqlCompilationRequest<T>(
         Assert.hasText(rsql, "rsql must not be blank");
         Objects.requireNonNull(ast, "ast must not be null");
         Objects.requireNonNull(definition, "definition must not be null");
-        conversionService = Objects.requireNonNull(conversionService, "conversionService must not be null");
+        Objects.requireNonNull(conversionService, "conversionService must not be null");
         operators = Objects.requireNonNull(operators, "operators must not be null");
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
@@ -27,7 +27,7 @@ public record RsqlCompilationRequest<T>(
     /** Validates required request components. */
     public RsqlCompilationRequest {
         Assert.hasText(rsql, "rsql must not be blank");
-        ast = Objects.requireNonNull(ast, "ast must not be null");
+        Objects.requireNonNull(ast, "ast must not be null");
         definition = Objects.requireNonNull(definition, "definition must not be null");
         conversionService = Objects.requireNonNull(conversionService, "conversionService must not be null");
         operators = Objects.requireNonNull(operators, "operators must not be null");

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/RsqlCompilationRequest.java
@@ -28,7 +28,7 @@ public record RsqlCompilationRequest<T>(
     public RsqlCompilationRequest {
         Assert.hasText(rsql, "rsql must not be blank");
         Objects.requireNonNull(ast, "ast must not be null");
-        definition = Objects.requireNonNull(definition, "definition must not be null");
+        Objects.requireNonNull(definition, "definition must not be null");
         conversionService = Objects.requireNonNull(conversionService, "conversionService must not be null");
         operators = Objects.requireNonNull(operators, "operators must not be null");
     }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
@@ -9,9 +9,9 @@ import java.util.List;
 import java.util.Objects;
 
 /** JPA state and converted arguments supplied to a custom operator predicate. */
-public record RsqlJpaPredicateContext(
+public record RsqlJpaPredicateContext<P>(
         CriteriaBuilder criteriaBuilder,
-        Path<?> path,
+        Path<P> path,
         Attribute<?, ?> attribute,
         List<Object> arguments,
         From<?, ?> root,

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
@@ -9,12 +9,12 @@ import java.util.List;
 import java.util.Objects;
 
 /** JPA state and converted arguments supplied to a custom operator predicate. */
-public record RsqlJpaPredicateContext<P, A, B>(
+public record RsqlJpaPredicateContext<P, A, B, R, J>(
         CriteriaBuilder criteriaBuilder,
         Path<P> path,
         Attribute<A, B> attribute,
         List<Object> arguments,
-        From<?, ?> root,
+        From<R, J> root,
         RsqlOperator operator) {
     /** Creates a custom-predicate context. */
     public RsqlJpaPredicateContext {

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
@@ -9,91 +9,20 @@ import java.util.List;
 import java.util.Objects;
 
 /** JPA state and converted arguments supplied to a custom operator predicate. */
-public final class RsqlJpaPredicateContext {
-    private final CriteriaBuilder criteriaBuilder;
-    private final Path<?> path;
-    private final Attribute<?, ?> attribute;
-    private final List<Object> arguments;
-    private final From<?, ?> root;
-    private final RsqlOperator operator;
-
-    /**
-     * Creates a custom-predicate context.
-     *
-     * @param criteriaBuilder active criteria builder
-     * @param path resolved JPA path for the public selector
-     * @param attribute terminal metamodel attribute, when available
-     * @param arguments immutable converted arguments
-     * @param root criteria root or treated subtype root
-     * @param operator logical operator being executed
-     */
-    public RsqlJpaPredicateContext(
-            CriteriaBuilder criteriaBuilder,
-            Path<?> path,
-            Attribute<?, ?> attribute,
-            List<Object> arguments,
-            From<?, ?> root,
-            RsqlOperator operator) {
-        this.criteriaBuilder = Objects.requireNonNull(criteriaBuilder, "criteriaBuilder must not be null");
-        this.path = Objects.requireNonNull(path, "path must not be null");
-        this.attribute = attribute;
-        this.arguments = List.copyOf(Objects.requireNonNull(arguments, "arguments must not be null"));
-        this.root = Objects.requireNonNull(root, "root must not be null");
-        this.operator = Objects.requireNonNull(operator, "operator must not be null");
-    }
-
-    /**
-     * Returns the active criteria builder.
-     *
-     * @return active criteria builder
-     */
-    public CriteriaBuilder criteriaBuilder() {
-        return criteriaBuilder;
-    }
-
-    /**
-     * Returns the resolved selector path.
-     *
-     * @return resolved path for the selector
-     */
-    public Path<?> path() {
-        return path;
-    }
-
-    /**
-     * Returns terminal metamodel information.
-     *
-     * @return terminal metamodel attribute, or {@code null}
-     */
-    public Attribute<?, ?> attribute() {
-        return attribute;
-    }
-
-    /**
-     * Returns all converted arguments.
-     *
-     * @return immutable converted argument list
-     */
-    public List<Object> arguments() {
-        return arguments;
-    }
-
-    /**
-     * Returns the path root.
-     *
-     * @return criteria root used to resolve the path
-     */
-    public From<?, ?> root() {
-        return root;
-    }
-
-    /**
-     * Returns the executing operator.
-     *
-     * @return logical operator being executed
-     */
-    public RsqlOperator operator() {
-        return operator;
+public record RsqlJpaPredicateContext(
+        CriteriaBuilder criteriaBuilder,
+        Path<?> path,
+        Attribute<?, ?> attribute,
+        List<Object> arguments,
+        From<?, ?> root,
+        RsqlOperator operator) {
+    /** Creates a custom-predicate context. */
+    public RsqlJpaPredicateContext {
+        Objects.requireNonNull(criteriaBuilder, "criteriaBuilder must not be null");
+        Objects.requireNonNull(path, "path must not be null");
+        arguments = List.copyOf(Objects.requireNonNull(arguments, "arguments must not be null"));
+        Objects.requireNonNull(root, "root must not be null");
+        Objects.requireNonNull(operator, "operator must not be null");
     }
 
     /**

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateContext.java
@@ -9,10 +9,10 @@ import java.util.List;
 import java.util.Objects;
 
 /** JPA state and converted arguments supplied to a custom operator predicate. */
-public record RsqlJpaPredicateContext<P>(
+public record RsqlJpaPredicateContext<P, A, B>(
         CriteriaBuilder criteriaBuilder,
         Path<P> path,
-        Attribute<?, ?> attribute,
+        Attribute<A, B> attribute,
         List<Object> arguments,
         From<?, ?> root,
         RsqlOperator operator) {

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateFactory.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/RsqlJpaPredicateFactory.java
@@ -13,5 +13,5 @@ public interface RsqlJpaPredicateFactory {
      * @param context custom predicate context
      * @return JPA predicate
      */
-    Predicate toPredicate(RsqlJpaPredicateContext context);
+    Predicate toPredicate(RsqlJpaPredicateContext<?, ?, ?, ?, ?> context);
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
@@ -97,8 +97,8 @@ public final class PerplexhubRsqlBackendAdapter implements RsqlBackendAdapter {
                 converter);
     }
 
-    private static RsqlJpaPredicateContext context(RSQLCustomPredicateInput input, RsqlOperator operator) {
-        return new RsqlJpaPredicateContext(
+    private static RsqlJpaPredicateContext<?, ?, ?, ?, ?> context(RSQLCustomPredicateInput input, RsqlOperator operator) {
+        return new RsqlJpaPredicateContext<>(
                 input.getCriteriaBuilder(),
                 input.getPath(),
                 input.getAttribute(),

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
@@ -175,7 +175,7 @@ public final class PerplexhubRsqlBackendAdapter implements RsqlBackendAdapter {
                 ComparisonNode comparison,
                 RSQLJPAPredicateConverter converter,
                 From<?, ?> root) {
-            return (Predicate) comparison.accept(converter, (From) root);
+            return (Predicate) comparison.accept(converter, root);
         }
     }
 }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/rsql/operator/RsqlOperatorDescriptor.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/rsql/operator/RsqlOperatorDescriptor.java
@@ -3,7 +3,6 @@ package io.github.ggomarighetti.searchhelper.rsql.operator;
 import cz.jirutka.rsql.parser.ast.ComparisonOperator;
 import io.github.ggomarighetti.searchhelper.rsql.backend.RsqlJpaPredicateFactory;
 import java.util.Collections;
-import java.util.function.Consumer;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Optional;

--- a/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
@@ -26,7 +26,7 @@ public record RuleViolation(
         Objects.requireNonNull(path, "path must not be null");
         Objects.requireNonNull(message, "message must not be null");
         Objects.requireNonNull(messageTemplate, "messageTemplate must not be null");
-        constraint = Objects.requireNonNull(constraint, "constraint must not be null");
+        Objects.requireNonNull(constraint, "constraint must not be null");
     }
 
     /**

--- a/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
@@ -23,7 +23,7 @@ public record RuleViolation(
 
     /** Validates all safe violation fields. */
     public RuleViolation {
-        path = Objects.requireNonNull(path, "path must not be null");
+        Objects.requireNonNull(path, "path must not be null");
         message = Objects.requireNonNull(message, "message must not be null");
         messageTemplate = Objects.requireNonNull(messageTemplate, "messageTemplate must not be null");
         constraint = Objects.requireNonNull(constraint, "constraint must not be null");

--- a/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
@@ -24,7 +24,7 @@ public record RuleViolation(
     /** Validates all safe violation fields. */
     public RuleViolation {
         Objects.requireNonNull(path, "path must not be null");
-        message = Objects.requireNonNull(message, "message must not be null");
+        Objects.requireNonNull(message, "message must not be null");
         messageTemplate = Objects.requireNonNull(messageTemplate, "messageTemplate must not be null");
         constraint = Objects.requireNonNull(constraint, "constraint must not be null");
     }

--- a/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
+++ b/src/main/java/io/github/ggomarighetti/searchhelper/validation/RuleViolation.java
@@ -25,7 +25,7 @@ public record RuleViolation(
     public RuleViolation {
         Objects.requireNonNull(path, "path must not be null");
         Objects.requireNonNull(message, "message must not be null");
-        messageTemplate = Objects.requireNonNull(messageTemplate, "messageTemplate must not be null");
+        Objects.requireNonNull(messageTemplate, "messageTemplate must not be null");
         constraint = Objects.requireNonNull(constraint, "constraint must not be null");
     }
 

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
@@ -9,7 +9,6 @@ import io.github.ggomarighetti.searchhelper.rsql.backend.RsqlBackendAdapter;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperator;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorArity;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorDescriptor;
-import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
 import io.github.ggomarighetti.searchhelper.rsql.RsqlCompilationRequest;
 import io.github.ggomarighetti.searchhelper.rsql.SearchRsqlEngine;
 import io.github.ggomarighetti.searchhelper.rsql.SearchRsqlEngineBuilder;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
@@ -204,12 +204,13 @@ class SearchRsqlAutoConfigurationTest {
             assertEquals(new CatalogCode("CAT123"),
                     engine.conversionService().convert("CAT123", CatalogCode.class));
 
+            PageRequest pageRequest = PageRequest.of(0, 10);
             RsqlFilterValidationException exception = assertThrows(
                     RsqlFilterValidationException.class,
                     () -> compiler.compile(
                             "code==BAD",
                             null,
-                            PageRequest.of(0, 10),
+                            pageRequest,
                             definition));
 
             assertEquals(RsqlFilterValidationException.RULES_FORBIDDEN, exception.code());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
@@ -167,12 +167,13 @@ class SearchRsqlAutoConfigurationTest {
                     .paging()
                     .build();
 
+            PageRequest pageRequest = PageRequest.of(0, 10);
             SearchDefinitionValidationException exception = assertThrows(
                     SearchDefinitionValidationException.class,
                     () -> compiler.compile(
                             "code==CAT123",
                             null,
-                            PageRequest.of(0, 10),
+                            pageRequest,
                             definition));
 
             assertEquals(SearchDefinitionValidationException.RSQL_CONFIGURATION_INVALID, exception.code());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/RsqlSearchAutoConfigurationTest.java
@@ -69,9 +69,10 @@ class SearchRsqlAutoConfigurationTest {
             compiler.compile("sku==SKU123", null, PageRequest.of(0, 10), definition);
             assertEquals(new Sku("SKU123"), engine.conversionService().convert("SKU123", Sku.class));
 
+            PageRequest pageRequest = PageRequest.of(0, 10);
             RsqlFilterValidationException exception =
                     assertThrows(RsqlFilterValidationException.class, () ->
-                            compiler.compile("sku==BAD", null, PageRequest.of(0, 10), definition));
+                            compiler.compile("sku==BAD", null, pageRequest, definition));
 
             assertEquals(RsqlFilterValidationException.RULES_FORBIDDEN, exception.code());
         });

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/SearchHelperAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/SearchHelperAutoConfigurationTest.java
@@ -74,12 +74,13 @@ class SearchHelperAutoConfigurationTest {
                             .paging()
                             .build();
 
+                    var pageRequest = org.springframework.data.domain.PageRequest.of(0, 25);
                     assertThrows(
                             SearchProtectionException.class,
                             () -> compiler.compile(
                                     "taxId=in=(1,2)",
                                     null,
-                                    org.springframework.data.domain.PageRequest.of(0, 25),
+                                    pageRequest,
                                     definition));
                 });
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/SearchHelperAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/SearchHelperAutoConfigurationTest.java
@@ -4,7 +4,6 @@ import io.github.ggomarighetti.searchhelper.compile.SearchCompiler;
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinitionFactory;
 import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.unit.TestTypes;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/SearchHelperPropertiesTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/autoconfigure/SearchHelperPropertiesTest.java
@@ -1,0 +1,220 @@
+package io.github.ggomarighetti.searchhelper.autoconfigure;
+
+import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import static java.util.Map.entry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SearchHelperPropertiesTest {
+    @Test
+    void bindsEveryPropertyGroupIntoPolicyAndBackendOptions() {
+        SearchHelperProperties properties = bind(Map.ofEntries(
+                entry("search.helper.rsql.enabled", "false"),
+                entry("search.helper.rsql.perplexhub.strict-equality", "false"),
+                entry("search.helper.rsql.perplexhub.like-escape-character", "!"),
+                entry("search.helper.rsql.max-length", "101"),
+                entry("search.helper.rsql.max-parentheses-depth", "4"),
+                entry("search.helper.rsql.max-nodes", "20"),
+                entry("search.helper.rsql.max-depth", "5"),
+                entry("search.helper.rsql.max-logical-children", "6"),
+                entry("search.helper.filter.max-comparisons", "7"),
+                entry("search.helper.filter.max-comparisons-per-selector", "3"),
+                entry("search.helper.filter.max-arguments-per-comparison", "4"),
+                entry("search.helper.filter.max-arguments-total", "15"),
+                entry("search.helper.filter.max-argument-length", "21"),
+                entry("search.helper.filter.max-in-values", "5"),
+                entry("search.helper.filter.max-not-in-values", "6"),
+                entry("search.helper.filter.max-between-ranges", "2"),
+                entry("search.helper.filter.max-negated-comparisons", "1"),
+                entry("search.helper.filter.max-or-branches", "8"),
+                entry("search.helper.filter.max-or-selectors", "4"),
+                entry("search.helper.filter.max-or-join-roots", "3"),
+                entry("search.helper.filter.max-heterogeneous-or-branches", "2"),
+                entry("search.helper.filter.max-joined-paths", "6"),
+                entry("search.helper.filter.max-to-many-paths", "2"),
+                entry("search.helper.filter.allow-to-many-filtering", "false"),
+                entry("search.helper.filter.require-distinct-for-to-many", "false"),
+                entry("search.helper.filter.like.max-pattern-length", "40"),
+                entry("search.helper.filter.like.min-literal-length", "2"),
+                entry("search.helper.filter.like.allow-leading-wildcard", "true"),
+                entry("search.helper.filter.like.allow-trailing-wildcard", "false"),
+                entry("search.helper.filter.like.allow-contains", "false"),
+                entry("search.helper.filter.like.max-wildcards", "2"),
+                entry("search.helper.filter.like.allow-ignore-case", "false"),
+                entry("search.helper.paging.min-page", "1"),
+                entry("search.helper.paging.max-page", "20"),
+                entry("search.helper.paging.min-size", "2"),
+                entry("search.helper.paging.max-size", "50"),
+                entry("search.helper.paging.max-offset", "1000"),
+                entry("search.helper.paging.allow-unpaged", "false"),
+                entry("search.helper.paging.default-unpaged-size", "25"),
+                entry("search.helper.paging.max-unpaged-size", "80"),
+                entry("search.helper.paging.page.allow-to-many-count", "true"),
+                entry("search.helper.paging.page.max-to-many-paths", "3"),
+                entry("search.helper.paging.page.allow-distinct-count", "false"),
+                entry("search.helper.paging.page.max-joined-paths", "4"),
+                entry("search.helper.paging.slice.enabled", "false"),
+                entry("search.helper.paging.slice.prefer-for-to-many", "false"),
+                entry("search.helper.paging.slice.max-size", "30"),
+                entry("search.helper.sorting.max-orders", "4"),
+                entry("search.helper.sorting.allow-relation-sorting", "false"),
+                entry("search.helper.sorting.max-relation-orders", "0"),
+                entry("search.helper.sorting.allow-ignore-case", "true"),
+                entry("search.helper.sorting.allow-null-handling", "true"),
+                entry("search.helper.sorting.max-joined-paths", "5"),
+                entry("search.helper.sorting.disallow-to-many-sorting", "false"),
+                entry("search.helper.query.enabled", "false"),
+                entry("search.helper.query.min-length", "2"),
+                entry("search.helper.query.max-length", "60"),
+                entry("search.helper.query.require-validator", "true"),
+                entry("search.helper.query.allow-with-to-many-filter", "false"),
+                entry("search.helper.query.allow-with-relation-sort", "false"),
+                entry("search.helper.query.allow-with-unpaged", "false"),
+                entry("search.helper.paths.max-depth", "4")));
+
+        SearchPolicy policy = properties.toPolicy();
+
+        assertFalse(properties.getRsql().isEnabled());
+        assertFalse(properties.getRsql().getPerplexhub().isStrictEquality());
+        assertEquals('!', properties.getRsql().getPerplexhub().getLikeEscapeCharacter());
+        assertEquals(101, properties.getRsql().getMaxLength());
+        assertEquals(4, properties.getRsql().getMaxParenthesesDepth());
+        assertEquals(20, properties.getRsql().getMaxNodes());
+        assertEquals(5, properties.getRsql().getMaxDepth());
+        assertEquals(6, properties.getRsql().getMaxLogicalChildren());
+        assertEquals(101, policy.rsql().maxLength());
+        assertEquals(4, policy.rsql().maxParenthesesDepth());
+        assertEquals(20, policy.rsql().maxNodes());
+        assertEquals(5, policy.rsql().maxDepth());
+        assertEquals(6, policy.rsql().maxLogicalChildren());
+
+        assertEquals(7, properties.getFilter().getMaxComparisons());
+        assertEquals(3, properties.getFilter().getMaxComparisonsPerSelector());
+        assertEquals(4, properties.getFilter().getMaxArgumentsPerComparison());
+        assertEquals(15, properties.getFilter().getMaxArgumentsTotal());
+        assertEquals(21, properties.getFilter().getMaxArgumentLength());
+        assertEquals(5, properties.getFilter().getMaxInValues());
+        assertEquals(6, properties.getFilter().getMaxNotInValues());
+        assertEquals(2, properties.getFilter().getMaxBetweenRanges());
+        assertEquals(1, properties.getFilter().getMaxNegatedComparisons());
+        assertEquals(8, properties.getFilter().getMaxOrBranches());
+        assertEquals(4, properties.getFilter().getMaxOrSelectors());
+        assertEquals(3, properties.getFilter().getMaxOrJoinRoots());
+        assertEquals(2, properties.getFilter().getMaxHeterogeneousOrBranches());
+        assertEquals(6, properties.getFilter().getMaxJoinedPaths());
+        assertEquals(2, properties.getFilter().getMaxToManyPaths());
+        assertFalse(properties.getFilter().isAllowToManyFiltering());
+        assertFalse(properties.getFilter().isRequireDistinctForToMany());
+        assertEquals(7, policy.filter().maxComparisons());
+        assertEquals(3, policy.filter().maxComparisonsPerSelector());
+        assertEquals(4, policy.filter().maxArgumentsPerComparison());
+        assertEquals(15, policy.filter().maxArgumentsTotal());
+        assertEquals(21, policy.filter().maxArgumentLength());
+        assertEquals(5, policy.filter().maxInValues());
+        assertEquals(6, policy.filter().maxNotInValues());
+        assertEquals(2, policy.filter().maxBetweenRanges());
+        assertEquals(1, policy.filter().maxNegatedComparisons());
+        assertEquals(8, policy.filter().maxOrBranches());
+        assertEquals(4, policy.filter().maxOrSelectors());
+        assertEquals(3, policy.filter().maxOrJoinRoots());
+        assertEquals(2, policy.filter().maxHeterogeneousOrBranches());
+        assertEquals(6, policy.filter().maxJoinedPaths());
+        assertEquals(2, policy.filter().maxToManyPaths());
+        assertFalse(policy.filter().allowToManyFiltering());
+        assertFalse(policy.filter().requireDistinctForToMany());
+
+        assertEquals(40, properties.getFilter().getLike().getMaxPatternLength());
+        assertEquals(2, properties.getFilter().getLike().getMinLiteralLength());
+        assertTrue(properties.getFilter().getLike().isAllowLeadingWildcard());
+        assertFalse(properties.getFilter().getLike().isAllowTrailingWildcard());
+        assertFalse(properties.getFilter().getLike().isAllowContains());
+        assertEquals(2, properties.getFilter().getLike().getMaxWildcards());
+        assertFalse(properties.getFilter().getLike().isAllowIgnoreCase());
+        assertEquals(40, policy.filter().like().maxPatternLength());
+        assertEquals(2, policy.filter().like().minLiteralLength());
+        assertTrue(policy.filter().like().allowLeadingWildcard());
+        assertFalse(policy.filter().like().allowTrailingWildcard());
+        assertFalse(policy.filter().like().allowContains());
+        assertEquals(2, policy.filter().like().maxWildcards());
+        assertFalse(policy.filter().like().allowIgnoreCase());
+
+        assertEquals(1, properties.getPaging().getMinPage());
+        assertEquals(20, properties.getPaging().getMaxPage());
+        assertEquals(2, properties.getPaging().getMinSize());
+        assertEquals(50, properties.getPaging().getMaxSize());
+        assertEquals(1000L, properties.getPaging().getMaxOffset());
+        assertFalse(properties.getPaging().isAllowUnpaged());
+        assertEquals(25, properties.getPaging().getDefaultUnpagedSize());
+        assertEquals(80, properties.getPaging().getMaxUnpagedSize());
+        assertEquals(1, policy.paging().minPage());
+        assertEquals(20, policy.paging().maxPage());
+        assertEquals(2, policy.paging().minSize());
+        assertEquals(50, policy.paging().maxSize());
+        assertEquals(1000L, policy.paging().maxOffset());
+        assertFalse(policy.paging().allowUnpaged());
+        assertEquals(25, policy.paging().defaultUnpagedSize());
+        assertEquals(80, policy.paging().maxUnpagedSize());
+
+        assertTrue(properties.getPaging().getPage().isAllowToManyCount());
+        assertEquals(3, properties.getPaging().getPage().getMaxToManyPaths());
+        assertFalse(properties.getPaging().getPage().isAllowDistinctCount());
+        assertEquals(4, properties.getPaging().getPage().getMaxJoinedPaths());
+        assertTrue(policy.paging().page().allowToManyCount());
+        assertEquals(3, policy.paging().page().maxToManyPaths());
+        assertFalse(policy.paging().page().allowDistinctCount());
+        assertEquals(4, policy.paging().page().maxJoinedPaths());
+
+        assertFalse(properties.getPaging().getSlice().isEnabled());
+        assertFalse(properties.getPaging().getSlice().isPreferForToMany());
+        assertEquals(30, properties.getPaging().getSlice().getMaxSize());
+        assertFalse(policy.paging().slice().enabled());
+        assertFalse(policy.paging().slice().preferForToMany());
+        assertEquals(30, policy.paging().slice().maxSize());
+
+        assertEquals(4, properties.getSorting().getMaxOrders());
+        assertFalse(properties.getSorting().isAllowRelationSorting());
+        assertEquals(0, properties.getSorting().getMaxRelationOrders());
+        assertTrue(properties.getSorting().isAllowIgnoreCase());
+        assertTrue(properties.getSorting().isAllowNullHandling());
+        assertEquals(5, properties.getSorting().getMaxJoinedPaths());
+        assertFalse(properties.getSorting().isDisallowToManySorting());
+        assertEquals(4, policy.sorting().maxOrders());
+        assertFalse(policy.sorting().allowRelationSorting());
+        assertEquals(0, policy.sorting().maxRelationOrders());
+        assertTrue(policy.sorting().allowIgnoreCase());
+        assertTrue(policy.sorting().allowNullHandling());
+        assertEquals(5, policy.sorting().maxJoinedPaths());
+        assertFalse(policy.sorting().disallowToManySorting());
+
+        assertFalse(properties.getQuery().isEnabled());
+        assertEquals(2, properties.getQuery().getMinLength());
+        assertEquals(60, properties.getQuery().getMaxLength());
+        assertTrue(properties.getQuery().isRequireValidator());
+        assertFalse(properties.getQuery().isAllowWithToManyFilter());
+        assertFalse(properties.getQuery().isAllowWithRelationSort());
+        assertFalse(properties.getQuery().isAllowWithUnpaged());
+        assertFalse(policy.query().enabled());
+        assertEquals(2, policy.query().minLength());
+        assertEquals(60, policy.query().maxLength());
+        assertTrue(policy.query().requireValidator());
+        assertFalse(policy.query().allowWithToManyFilter());
+        assertFalse(policy.query().allowWithRelationSort());
+        assertFalse(policy.query().allowWithUnpaged());
+
+        assertEquals(4, properties.getPaths().getMaxDepth());
+        assertEquals(4, policy.paths().maxDepth());
+    }
+
+    private static SearchHelperProperties bind(Map<String, String> values) {
+        SearchHelperProperties properties = new SearchHelperProperties();
+        new Binder(new MapConfigurationPropertySource(values))
+                .bind("search.helper", Bindable.ofInstance(properties));
+        return properties;
+    }
+}

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
@@ -47,13 +47,12 @@ class RsqlPropertyTest {
 
         for (int i = 0; i < 250; i++) {
             String input = generator.comparisonWithUnknownSelector();
-            try {
-                guard.specification(input, definition);
-                fail("Unknown selector unexpectedly compiled: " + escaped(input));
-            } catch (Throwable throwable) {
-                if (!SearchPropertyFixtures.isExpectedRsqlThrowable(throwable)) {
-                    fail("Unexpected throwable for unknown selector input [" + escaped(input) + "]", throwable);
-                }
+            Throwable throwable = assertThrows(
+                    Throwable.class,
+                    () -> guard.specification(input, definition),
+                    "Unknown selector unexpectedly compiled: " + escaped(input));
+            if (!SearchPropertyFixtures.isExpectedRsqlThrowable(throwable)) {
+                fail("Unexpected throwable for unknown selector input [" + escaped(input) + "]", throwable);
             }
         }
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
@@ -65,13 +65,12 @@ class RsqlPropertyTest {
 
         for (int i = 0; i < 250; i++) {
             String input = generator.comparisonWithDisallowedOperator();
-            try {
-                guard.specification(input, definition);
-                fail("Disallowed operator unexpectedly compiled: " + escaped(input));
-            } catch (Throwable throwable) {
-                if (!SearchPropertyFixtures.isExpectedRsqlThrowable(throwable)) {
-                    fail("Unexpected throwable for disallowed operator input [" + escaped(input) + "]", throwable);
-                }
+            Throwable throwable = assertThrows(
+                    Throwable.class,
+                    () -> guard.specification(input, definition),
+                    "Disallowed operator unexpectedly compiled: " + escaped(input));
+            if (!SearchPropertyFixtures.isExpectedRsqlThrowable(throwable)) {
+                fail("Unexpected throwable for disallowed operator input [" + escaped(input) + "]", throwable);
             }
         }
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
@@ -203,8 +203,9 @@ class RsqlPropertyTest {
             String input,
             SearchDefinition<Product> definition,
             String expectedRule) {
+        RsqlSearchGuard guard = new RsqlSearchGuard();
         SearchProtectionException exception =
-                assertThrows(SearchProtectionException.class, () -> new RsqlSearchGuard().specification(input, definition));
+                assertThrows(SearchProtectionException.class, () -> guard.specification(input, definition));
         assertEquals(SearchProtectionException.PROTECTION_RULE_EXCEEDED, exception.code(), input);
         assertEquals(expectedRule, exception.rule(), input);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
@@ -193,8 +193,9 @@ class RsqlPropertyTest {
     }
 
     private static void assertLimitExceeded(String input, SearchDefinition<Product> definition) {
+        RsqlSearchGuard guard = new RsqlSearchGuard();
         RsqlFilterValidationException exception =
-                assertThrows(RsqlFilterValidationException.class, () -> new RsqlSearchGuard().specification(input, definition));
+                assertThrows(RsqlFilterValidationException.class, () -> guard.specification(input, definition));
         assertEquals(RsqlFilterValidationException.LIMIT_EXCEEDED, exception.code(), input);
     }
 

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlPropertyTest.java
@@ -1,6 +1,5 @@
 package io.github.ggomarighetti.searchhelper.compile;
 
-import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.EQUAL;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -211,7 +211,7 @@ class RsqlSearchGuardTest {
 
         assertEquals("=first=", descriptor.symbol());
         assertEquals(List.of("=first=", "=second="), descriptor.symbols().stream().toList());
-        Set<String> symbols = descriptor.symbols();
+        var symbols = descriptor.symbols();
         assertThrows(UnsupportedOperationException.class, symbols::clear);
     }
 

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -475,10 +475,11 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsRsqlArgumentLimitsBeforeConversionAndRules() {
+        SearchDefinition<TestTypes.Product> perComparisonDefinition = filters(limits -> limits
+                .filter(filter -> filter.maxArgumentsPerComparison(1)));
         SearchProtectionException perComparison = assertThrows(
                 SearchProtectionException.class,
-                () -> guard.specification("taxId=in=(20123456789,20987654321)", filters(limits -> limits
-                        .filter(filter -> filter.maxArgumentsPerComparison(1)))));
+                () -> guard.specification("taxId=in=(20123456789,20987654321)", perComparisonDefinition));
         SearchProtectionException total = assertThrows(
                 SearchProtectionException.class,
                 () -> guard.specification(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -10,7 +10,6 @@ import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.rsql.backend.RsqlBackendAdapter;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperator;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorDescriptor;
-import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
 import io.github.ggomarighetti.searchhelper.rsql.RsqlCompilationRequest;
 import io.github.ggomarighetti.searchhelper.unit.TestTypes;
 import io.github.ggomarighetti.searchhelper.rsql.SearchRsqlEngine;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -404,10 +404,11 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsRsqlRawInputLongerThanLimit() {
+        SearchDefinition<TestTypes.Product> definition = filters(limits -> limits
+                .rsql(rsql -> rsql.maxLength(10)));
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("taxId==20123456789", filters(limits -> limits
-                        .rsql(rsql -> rsql.maxLength(10)))));
+                () -> guard.specification("taxId==20123456789", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.LIMIT_EXCEEDED);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -375,9 +375,10 @@ class RsqlSearchGuardTest {
 
     @Test
     void returnsRulesForbiddenWhenParsedFilterBreaksMultipleRules() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("passwordHash==abc;email!=not-an-email", filters()));
+                () -> guard.specification("passwordHash==abc;email!=not-an-email", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
         assertEquals(2, exception.errors().size());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -480,11 +480,13 @@ class RsqlSearchGuardTest {
         SearchProtectionException perComparison = assertThrows(
                 SearchProtectionException.class,
                 () -> guard.specification("taxId=in=(20123456789,20987654321)", perComparisonDefinition));
+        SearchDefinition<TestTypes.Product> totalDefinition =
+                filters(limits -> limits.filter(filter -> filter.maxArgumentsTotal(3)));
         SearchProtectionException total = assertThrows(
                 SearchProtectionException.class,
                 () -> guard.specification(
                         "taxId=in=(20123456789,20987654321);taxId=in=(30123456789,30987654321)",
-                        filters(limits -> limits.filter(filter -> filter.maxArgumentsTotal(3)))));
+                        totalDefinition));
         SearchProtectionException length = assertThrows(
                 SearchProtectionException.class,
                 () -> guard.specification("email==person@example.com", filters(limits -> limits

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -437,9 +437,10 @@ class RsqlSearchGuardTest {
     void rejectsRsqlAstNodeComparisonDepthAndLogicalChildLimits() {
         String filter = "taxId==20123456789;email==person@example.com";
 
+        SearchDefinition<TestTypes.Product> nodesDefinition = filters(limits -> limits.rsql(rsql -> rsql.maxNodes(1)));
         RsqlFilterValidationException nodes = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification(filter, filters(limits -> limits.rsql(rsql -> rsql.maxNodes(1)))));
+                () -> guard.specification(filter, nodesDefinition));
         SearchProtectionException comparisons = assertThrows(
                 SearchProtectionException.class,
                 () -> guard.specification(filter, filters(limits -> limits.filter(value -> value.maxComparisons(1)))));

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -330,9 +330,10 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsOperatorNotAllowedForField() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("taxId!=20123456789", filters()));
+                () -> guard.specification("taxId!=20123456789", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
         RsqlValidationError error = exception.errors().get(0);

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -450,10 +450,11 @@ class RsqlSearchGuardTest {
         RsqlFilterValidationException depth = assertThrows(
                 RsqlFilterValidationException.class,
                 () -> guard.specification(filter, depthDefinition));
+        SearchDefinition<TestTypes.Product> childrenDefinition =
+                filters(limits -> limits.rsql(rsql -> rsql.maxLogicalChildren(1)));
         RsqlFilterValidationException children = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification(filter,
-                        filters(limits -> limits.rsql(rsql -> rsql.maxLogicalChildren(1)))));
+                () -> guard.specification(filter, childrenDefinition));
 
         assertValidationCode(nodes, RsqlFilterValidationException.LIMIT_EXCEEDED);
         assertProtectionRule(comparisons, "filter.max-comparisons");

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -487,10 +487,11 @@ class RsqlSearchGuardTest {
                 () -> guard.specification(
                         "taxId=in=(20123456789,20987654321);taxId=in=(30123456789,30987654321)",
                         totalDefinition));
+        SearchDefinition<TestTypes.Product> lengthDefinition = filters(limits -> limits
+                .filter(filter -> filter.maxArgumentLength(5)));
         SearchProtectionException length = assertThrows(
                 SearchProtectionException.class,
-                () -> guard.specification("email==person@example.com", filters(limits -> limits
-                        .filter(filter -> filter.maxArgumentLength(5)))));
+                () -> guard.specification("email==person@example.com", lengthDefinition));
 
         assertProtectionRule(perComparison, "filter.max-arguments-per-comparison");
         assertProtectionRule(total, "filter.max-arguments-total");

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -395,8 +395,9 @@ class RsqlSearchGuardTest {
 
     @Test
     void returnsParseViolationWhenRsqlCannotBeParsed() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception =
-                assertThrows(RsqlFilterValidationException.class, () -> guard.specification("taxId==", filters()));
+                assertThrows(RsqlFilterValidationException.class, () -> guard.specification("taxId==", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.PARSE_ERROR);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -211,7 +211,8 @@ class RsqlSearchGuardTest {
 
         assertEquals("=first=", descriptor.symbol());
         assertEquals(List.of("=first=", "=second="), descriptor.symbols().stream().toList());
-        assertThrows(UnsupportedOperationException.class, () -> descriptor.symbols().clear());
+        List<String> symbols = descriptor.symbols();
+        assertThrows(UnsupportedOperationException.class, symbols::clear);
     }
 
     @Test

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -105,10 +105,11 @@ class RsqlSearchGuardTest {
                         .backend(throwingBackend)
                         .build(),
                 SearchPolicy.defaults());
+        SearchDefinition<TestTypes.Product> definition = filters();
 
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> throwingGuard.specification("taxId==20123456789", filters()));
+                () -> throwingGuard.specification("taxId==20123456789", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
     }
@@ -543,8 +544,9 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsNullRsqlAsLimitViolation() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception =
-                assertThrows(RsqlFilterValidationException.class, () -> guard.specification(null, filters()));
+                assertThrows(RsqlFilterValidationException.class, () -> guard.specification(null, definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.LIMIT_EXCEEDED);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -362,9 +362,10 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsAnyInvalidArgumentOfMultiValueOperators() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("taxId=in=(20123456789,123)", filters()));
+                () -> guard.specification("taxId=in=(20123456789,123)", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
         assertEquals(1, exception.errors().size());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -441,9 +441,11 @@ class RsqlSearchGuardTest {
         RsqlFilterValidationException nodes = assertThrows(
                 RsqlFilterValidationException.class,
                 () -> guard.specification(filter, nodesDefinition));
+        SearchDefinition<TestTypes.Product> comparisonsDefinition =
+                filters(limits -> limits.filter(value -> value.maxComparisons(1)));
         SearchProtectionException comparisons = assertThrows(
                 SearchProtectionException.class,
-                () -> guard.specification(filter, filters(limits -> limits.filter(value -> value.maxComparisons(1)))));
+                () -> guard.specification(filter, comparisonsDefinition));
         RsqlFilterValidationException depth = assertThrows(
                 RsqlFilterValidationException.class,
                 () -> guard.specification(filter, filters(limits -> limits.rsql(rsql -> rsql.maxDepth(1)))));

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -1,5 +1,9 @@
 package io.github.ggomarighetti.searchhelper.compile;
 
+import cz.jirutka.rsql.parser.ast.ComparisonNode;
+import cz.jirutka.rsql.parser.ast.ComparisonOperator;
+import cz.jirutka.rsql.parser.ast.Node;
+import cz.jirutka.rsql.parser.ast.RSQLVisitor;
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.exception.RsqlFilterValidationException;
 import io.github.ggomarighetti.searchhelper.exception.RsqlValidationError;
@@ -9,10 +13,14 @@ import io.github.ggomarighetti.searchhelper.filter.FilterOperator;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.rsql.backend.RsqlBackendAdapter;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperator;
+import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorArity;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorDescriptor;
+import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorRegistry;
 import io.github.ggomarighetti.searchhelper.rsql.RsqlCompilationRequest;
+import io.github.ggomarighetti.searchhelper.rsql.RsqlAst;
 import io.github.ggomarighetti.searchhelper.unit.TestTypes;
 import io.github.ggomarighetti.searchhelper.rsql.SearchRsqlEngine;
+import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -33,6 +41,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RsqlSearchGuardTest {
     private final RsqlSearchGuard guard = new RsqlSearchGuard();
+
+    @Test
+    void exposesConfiguredEngineAndPolicy() {
+        RsqlSearchGuard conversionGuard =
+                new RsqlSearchGuard(ApplicationConversionService.getSharedInstance());
+        SearchRsqlEngine engine = SearchRsqlEngine.defaults();
+        SearchPolicy policy = SearchPolicy.builder()
+                .filter(filter -> filter.maxComparisons(3))
+                .build();
+        RsqlSearchGuard configuredGuard = new RsqlSearchGuard(engine, policy);
+
+        assertNotNull(conversionGuard.engine());
+        assertEquals(SearchPolicy.defaults(), conversionGuard.policy());
+        assertEquals(engine, configuredGuard.engine());
+        assertEquals(policy, configuredGuard.policy());
+    }
 
     @Test
     void returnsSpecificationForAllowedFieldOperatorAndArgument() {
@@ -68,6 +92,55 @@ class RsqlSearchGuardTest {
     }
 
     @Test
+    void wrapsImmediateBackendCompilationFailures() {
+        RsqlBackendAdapter throwingBackend = new RsqlBackendAdapter() {
+            @Override
+            public <T> Specification<T> compile(RsqlCompilationRequest<T> request) {
+                throw new IllegalStateException("boom");
+            }
+        };
+        RsqlSearchGuard throwingGuard = new RsqlSearchGuard(
+                SearchRsqlEngine.builder()
+                        .conversionService(ApplicationConversionService.getSharedInstance())
+                        .backend(throwingBackend)
+                        .build(),
+                SearchPolicy.defaults());
+
+        RsqlFilterValidationException exception = assertThrows(
+                RsqlFilterValidationException.class,
+                () -> throwingGuard.specification("taxId==20123456789", filters()));
+
+        assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
+    }
+
+    @Test
+    void preservesDeferredRsqlFilterValidationExceptions() {
+        RsqlFilterValidationException expected = new RsqlFilterValidationException(
+                RsqlFilterValidationException.RULES_FORBIDDEN,
+                "already guarded");
+        RsqlBackendAdapter throwingBackend = new RsqlBackendAdapter() {
+            @Override
+            public <T> Specification<T> compile(RsqlCompilationRequest<T> request) {
+                return (root, query, criteriaBuilder) -> {
+                    throw expected;
+                };
+            }
+        };
+        RsqlSearchGuard throwingGuard = new RsqlSearchGuard(
+                SearchRsqlEngine.builder()
+                        .conversionService(ApplicationConversionService.getSharedInstance())
+                        .backend(throwingBackend)
+                        .build(),
+                SearchPolicy.defaults());
+
+        Specification<TestTypes.Product> specification = throwingGuard.specification("taxId==20123456789", filters());
+
+        assertEquals(expected, assertThrows(
+                RsqlFilterValidationException.class,
+                () -> specification.toPredicate(null, null, null)));
+    }
+
+    @Test
     void enablesDistinctOnlyWhenTheUsedFilterTraversesACollectionValuedPath() {
         AtomicReference<Boolean> distinct = new AtomicReference<>();
         RsqlBackendAdapter distinctCapturingBackend = new RsqlBackendAdapter() {
@@ -99,6 +172,9 @@ class RsqlSearchGuardTest {
         assertFalse(distinct.get());
 
         distinctCapturingGuard.specification("reviewRating==5", definition);
+        assertTrue(distinct.get());
+
+        distinctCapturingGuard.specification("amount==10.50;reviewRating==5", definition);
         assertTrue(distinct.get());
     }
 
@@ -344,6 +420,69 @@ class RsqlSearchGuardTest {
     }
 
     @Test
+    void rejectsDeclaredSelectorWhenFilteringIsDisabled() {
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class))
+                .build();
+
+        RsqlFilterValidationException exception = assertThrows(
+                RsqlFilterValidationException.class,
+                () -> guard.specification("email==person@example.com", definition));
+
+        assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
+        RsqlValidationError error = exception.errors().get(0);
+        assertEquals(RsqlValidationError.FILTERING_DISABLED, error.code());
+        assertEquals("$.selector", error.astPath());
+        assertEquals("email", error.selector());
+        assertEquals("EQUAL", error.operator());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void rejectsOperatorWithInvalidArity() throws ReflectiveOperationException {
+        RsqlOperator pair = RsqlOperator.of("PAIR");
+        RsqlOperatorDescriptor descriptor = RsqlOperatorDescriptor.builder(pair)
+                .symbol("=pair=")
+                .arity(RsqlOperatorArity.exact(2))
+                .argumentType(String.class)
+                .jpaPredicate(context -> context.criteriaBuilder().conjunction())
+                .build();
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class)
+                        .filterable(filter -> filter.allow(pair, String.class, operator -> {})))
+                .build();
+        RsqlRulesValidator validator = validator(definition, new RsqlOperatorRegistry(List.of(descriptor)));
+
+        List<RsqlValidationError> errors = validator.validate(ast(new ComparisonNode(
+                new ComparisonOperator("=pair=", true),
+                "email",
+                List.of("person@example.com"))));
+
+        RsqlValidationError error = errors.get(0);
+        assertEquals(RsqlValidationError.OPERATOR_INVALID_ARITY, error.code());
+        assertEquals("$.arguments", error.astPath());
+        assertEquals("email", error.selector());
+        assertEquals("PAIR", error.operator());
+    }
+
+    @Test
+    void reportsUnsupportedAstNodeAndUnregisteredOperator() throws ReflectiveOperationException {
+        RsqlRulesValidator validator = validator(filters(), SearchRsqlEngine.defaults().operators());
+
+        List<RsqlValidationError> unsupported = validator.validate(ast(new UnsupportedNode()));
+        List<RsqlValidationError> unregistered = validator.validate(ast(new ComparisonNode(
+                new ComparisonOperator("=ghost="),
+                "taxId",
+                List.of("20123456789"))));
+
+        assertEquals(RsqlValidationError.FIELD_NOT_ALLOWED, unsupported.get(0).code());
+        assertEquals("$", unsupported.get(0).astPath());
+        assertEquals(RsqlValidationError.OPERATOR_NOT_ALLOWED, unregistered.get(0).code());
+        assertEquals("$.operator", unregistered.get(0).astPath());
+        assertEquals("taxId", unregistered.get(0).selector());
+    }
+
+    @Test
     void rejectsInvalidArgumentWithTypedValidator() {
         SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception = assertThrows(
@@ -400,6 +539,14 @@ class RsqlSearchGuardTest {
                 assertThrows(RsqlFilterValidationException.class, () -> guard.specification("taxId==", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.PARSE_ERROR);
+    }
+
+    @Test
+    void rejectsNullRsqlAsLimitViolation() {
+        RsqlFilterValidationException exception =
+                assertThrows(RsqlFilterValidationException.class, () -> guard.specification(null, filters()));
+
+        assertValidationCode(exception, RsqlFilterValidationException.LIMIT_EXCEEDED);
     }
 
     @Test
@@ -563,5 +710,34 @@ class RsqlSearchGuardTest {
     private static void assertProtectionRule(SearchProtectionException exception, String expectedRule) {
         assertEquals(SearchProtectionException.PROTECTION_RULE_EXCEEDED, exception.code());
         assertEquals(expectedRule, exception.rule());
+    }
+
+    private static RsqlRulesValidator validator(
+            SearchDefinition<?> definition,
+            RsqlOperatorRegistry operators) {
+        return new RsqlRulesValidator(
+                definition,
+                ApplicationConversionService.getSharedInstance(),
+                SearchPolicy.defaults().rsql(),
+                new SearchProtectionContext(SearchPolicy.defaults(), SearchCompilationMode.PAGE),
+                operators);
+    }
+
+    private static RsqlAst ast(Node node) throws ReflectiveOperationException {
+        Constructor<RsqlAst> constructor = RsqlAst.class.getDeclaredConstructor(Node.class, List.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(node, List.of());
+    }
+
+    private static final class UnsupportedNode implements Node {
+        @Override
+        public <R, A> R accept(RSQLVisitor<R, A> visitor, A param) {
+            return null;
+        }
+
+        @Override
+        public <R, A> R accept(RSQLVisitor<R, A> visitor) {
+            return null;
+        }
     }
 }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -415,10 +415,11 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsRsqlParenthesesNestingBeforeParsing() {
+        SearchDefinition<TestTypes.Product> definition = filters(limits -> limits
+                .rsql(rsql -> rsql.maxParenthesesDepth(2)));
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("(((taxId==20123456789)))", filters(limits -> limits
-                        .rsql(rsql -> rsql.maxParenthesesDepth(2)))));
+                () -> guard.specification("(((taxId==20123456789)))", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.LIMIT_EXCEEDED);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -345,9 +345,10 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsInvalidArgumentWithTypedValidator() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("taxId==123", filters()));
+                () -> guard.specification("taxId==123", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
         RsqlValidationError error = exception.errors().get(0);

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -6,7 +6,6 @@ import io.github.ggomarighetti.searchhelper.exception.RsqlValidationError;
 import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidationException;
 import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.filter.FilterOperator;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Status;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.rsql.backend.RsqlBackendAdapter;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -211,7 +211,7 @@ class RsqlSearchGuardTest {
 
         assertEquals("=first=", descriptor.symbol());
         assertEquals(List.of("=first=", "=second="), descriptor.symbols().stream().toList());
-        List<String> symbols = descriptor.symbols();
+        Set<String> symbols = descriptor.symbols();
         assertThrows(UnsupportedOperationException.class, symbols::clear);
     }
 

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -6,7 +6,6 @@ import io.github.ggomarighetti.searchhelper.exception.RsqlValidationError;
 import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidationException;
 import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.filter.FilterOperator;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Status;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.rsql.backend.RsqlBackendAdapter;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperator;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -464,10 +464,11 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsRsqlOrBranchLimit() {
+        SearchDefinition<TestTypes.Product> definition = filters(limits -> limits
+                .filter(filter -> filter.maxOrBranches(1)));
         SearchProtectionException exception = assertThrows(
                 SearchProtectionException.class,
-                () -> guard.specification("taxId==20123456789,email==person@example.com", filters(limits -> limits
-                        .filter(filter -> filter.maxOrBranches(1)))));
+                () -> guard.specification("taxId==20123456789,email==person@example.com", definition));
 
         assertProtectionRule(exception, "filter.max-or-branches");
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -315,9 +315,10 @@ class RsqlSearchGuardTest {
 
     @Test
     void rejectsUnknownField() {
+        SearchDefinition<TestTypes.Product> definition = filters();
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification("passwordHash==abc", filters()));
+                () -> guard.specification("passwordHash==abc", definition));
 
         assertValidationCode(exception, RsqlFilterValidationException.RULES_FORBIDDEN);
         assertEquals(1, exception.errors().size());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/RsqlSearchGuardTest.java
@@ -446,9 +446,10 @@ class RsqlSearchGuardTest {
         SearchProtectionException comparisons = assertThrows(
                 SearchProtectionException.class,
                 () -> guard.specification(filter, comparisonsDefinition));
+        SearchDefinition<TestTypes.Product> depthDefinition = filters(limits -> limits.rsql(rsql -> rsql.maxDepth(1)));
         RsqlFilterValidationException depth = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> guard.specification(filter, filters(limits -> limits.rsql(rsql -> rsql.maxDepth(1)))));
+                () -> guard.specification(filter, depthDefinition));
         RsqlFilterValidationException children = assertThrows(
                 RsqlFilterValidationException.class,
                 () -> guard.specification(filter,

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -276,12 +276,11 @@ class SearchPageableGuardTest {
         SearchPageableValidationException tooManyOrders = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(tooManySorts, definition));
+        PageRequest duplicatedSort = PageRequest.of(0, 25,
+                Sort.by(Sort.Order.asc("customerName"), Sort.Order.desc("customerName")));
         SearchPageableValidationException duplicatedSelector = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(
-                        PageRequest.of(0, 25,
-                                Sort.by(Sort.Order.asc("customerName"), Sort.Order.desc("customerName"))),
-                        definition()));
+                () -> guard.pageable(duplicatedSort, definition));
         SearchPageableValidationException ignoreCase = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -203,9 +203,10 @@ class SearchPageableGuardTest {
 
         assertEquals(3, guard.pageable(PageRequest.of(3, 50), definition).getPageNumber());
 
+        PageRequest invalidPage = PageRequest.of(4, 50);
         SearchPageableValidationException pageException = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(4, 50), definition));
+                () -> guard.pageable(invalidPage, definition));
         SearchPageableValidationException sizeException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(PageRequest.of(0, 101), definition));

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -207,9 +207,10 @@ class SearchPageableGuardTest {
         SearchPageableValidationException pageException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(invalidPage, definition));
+        PageRequest invalidSize = PageRequest.of(0, 101);
         SearchPageableValidationException sizeException = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(0, 101), definition));
+                () -> guard.pageable(invalidSize, definition));
 
         assertValidationCode(pageException, SearchPageableValidationException.PAGE_RULES_FORBIDDEN);
         assertValidationCode(sizeException, SearchPageableValidationException.PAGE_RULES_FORBIDDEN);

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -229,9 +229,10 @@ class SearchPageableGuardTest {
         SearchPageableValidationException pageException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(invalidPage, definition));
+        PageRequest invalidSize = PageRequest.of(0, 101);
         SearchPageableValidationException sizeException = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(0, 101), definition()));
+                () -> guard.pageable(invalidSize, definition));
         SearchPageableValidationException offsetException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(PageRequest.of(100, 101), definition(SearchPolicy.builder()

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -285,11 +285,10 @@ class SearchPageableGuardTest {
         SearchPageableValidationException ignoreCase = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(ignoreCaseSort, definition));
+        PageRequest nullHandlingSort = PageRequest.of(0, 25, Sort.by(Sort.Order.asc("amount").nullsLast()));
         SearchPageableValidationException nullHandling = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(
-                        PageRequest.of(0, 25, Sort.by(Sort.Order.asc("amount").nullsLast())),
-                        definition()));
+                () -> guard.pageable(nullHandlingSort, definition));
 
         assertValidationCode(tooManyOrders, SearchPageableValidationException.SORT_LIMIT_EXCEEDED);
         assertValidationCode(duplicatedSelector, SearchPageableValidationException.SORT_LIMIT_EXCEEDED);

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -161,10 +161,11 @@ class SearchPageableGuardTest {
                 .fields(fields -> fields.add("email", String.class))
                 .paging()
                 .build();
+        PageRequest pageRequest = PageRequest.of(0, 25, Sort.by("email"));
 
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(0, 25, Sort.by("email")), definition));
+                () -> guard.pageable(pageRequest, definition));
 
         assertValidationCode(exception, SearchPageableValidationException.SORT_RULES_FORBIDDEN);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -218,7 +218,8 @@ class SearchPageableGuardTest {
         assertTrue(pageException.violations().get(0).constraint().endsWith(".Max"));
         assertEquals("size", sizeException.violations().get(0).path());
         assertTrue(sizeException.violations().get(0).constraint().endsWith(".Max"));
-        assertThrows(UnsupportedOperationException.class, () -> pageException.violations().clear());
+        var violations = pageException.violations();
+        assertThrows(UnsupportedOperationException.class, violations::clear);
     }
 
     @Test

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -132,12 +132,12 @@ class SearchPageableGuardTest {
 
     @Test
     void rejectsUnpagedLimitAboveConfiguredMaximum() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchPolicy.builder()
-                        .paging(paging -> paging
-                                .maxUnpagedSize(10)
-                                .unpagedSize(11))
-                        .build());
+        var builder = SearchPolicy.builder()
+                .paging(paging -> paging
+                        .maxUnpagedSize(10)
+                        .unpagedSize(11));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertEquals(
                 "paging.defaultUnpagedSize must be less than or equal to paging.maxUnpagedSize",

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -104,9 +104,11 @@ class SearchPageableGuardTest {
 
     @Test
     void rejectsUnpagedPageableByDefault() {
+        Pageable pageable = Pageable.unpaged();
+        SearchDefinition<TestTypes.Product> definition = definition();
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(Pageable.unpaged(), definition()));
+                () -> guard.pageable(pageable, definition));
 
         assertValidationCode(exception, SearchPageableValidationException.PAGE_LIMIT_EXCEEDED);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -146,9 +146,11 @@ class SearchPageableGuardTest {
 
     @Test
     void rejectsUnknownSortSelector() {
+        PageRequest pageRequest = PageRequest.of(0, 25, Sort.by("passwordHash"));
+        SearchDefinition<TestTypes.Product> definition = definition();
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(0, 25, Sort.by("passwordHash")), definition()));
+                () -> guard.pageable(pageRequest, definition));
 
         assertValidationCode(exception, SearchPageableValidationException.SORT_RULES_FORBIDDEN);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -172,9 +172,11 @@ class SearchPageableGuardTest {
 
     @Test
     void rejectsSortDirectionThatIsNotAllowed() {
+        PageRequest pageRequest = PageRequest.of(0, 25, Sort.by(Sort.Order.asc("createdAt")));
+        SearchDefinition<TestTypes.Product> definition = definition();
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(0, 25, Sort.by(Sort.Order.asc("createdAt"))), definition()));
+                () -> guard.pageable(pageRequest, definition));
 
         assertValidationCode(exception, SearchPageableValidationException.SORT_RULES_FORBIDDEN);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -262,9 +262,10 @@ class SearchPageableGuardTest {
         assertTrue(boundedUnpaged.isPaged());
         assertEquals(40, boundedUnpaged.getPageSize());
 
+        PageRequest oversizedPage = PageRequest.of(0, 6);
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> limitedGuard.pageable(PageRequest.of(0, 6), definition));
+                () -> limitedGuard.pageable(oversizedPage, definition));
         assertValidationCode(exception, SearchPageableValidationException.PAGE_LIMIT_EXCEEDED);
     }
 

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -271,11 +271,11 @@ class SearchPageableGuardTest {
 
     @Test
     void rejectsSortSafetyLimits() {
+        SearchDefinition<TestTypes.Product> definition = definition();
+        PageRequest tooManySorts = PageRequest.of(0, 25, Sort.by("customerName", "amount", "createdAt", "email"));
         SearchPageableValidationException tooManyOrders = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(
-                        PageRequest.of(0, 25, Sort.by("customerName", "amount", "createdAt", "email")),
-                        definition()));
+                () -> guard.pageable(tooManySorts, definition));
         SearchPageableValidationException duplicatedSelector = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -186,10 +186,11 @@ class SearchPageableGuardTest {
         SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder().entity(TestTypes.Product.class)
                 .fields(fields -> fields.add("email", String.class).sortable())
                 .build();
+        PageRequest pageRequest = PageRequest.of(0, 25);
 
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(0, 25), definition));
+                () -> guard.pageable(pageRequest, definition));
 
         assertValidationCode(exception, SearchPageableValidationException.PAGE_RULES_FORBIDDEN);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -14,7 +14,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.data.domain.Sort.Direction.ASC;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -281,11 +281,10 @@ class SearchPageableGuardTest {
         SearchPageableValidationException duplicatedSelector = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(duplicatedSort, definition));
+        PageRequest ignoreCaseSort = PageRequest.of(0, 25, Sort.by(Sort.Order.asc("amount").ignoreCase()));
         SearchPageableValidationException ignoreCase = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(
-                        PageRequest.of(0, 25, Sort.by(Sort.Order.asc("amount").ignoreCase())),
-                        definition()));
+                () -> guard.pageable(ignoreCaseSort, definition));
         SearchPageableValidationException nullHandling = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -2,7 +2,6 @@ package io.github.ggomarighetti.searchhelper.compile;
 
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.exception.SearchPageableValidationException;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.unit.TestTypes;
 import java.math.BigDecimal;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -224,9 +224,11 @@ class SearchPageableGuardTest {
 
     @Test
     void rejectsPageableSafetyLimitsBeforeHibernateRules() {
+        SearchDefinition<TestTypes.Product> definition = definition();
+        PageRequest invalidPage = PageRequest.of(101, 1);
         SearchPageableValidationException pageException = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(101, 1), definition()));
+                () -> guard.pageable(invalidPage, definition));
         SearchPageableValidationException sizeException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(PageRequest.of(0, 101), definition()));

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -75,13 +75,12 @@ class SearchPageableGuardTest {
     @Test
     void rejectsDifferentSortSelectorsThatResolveToSameInternalPath() {
         SearchDefinition<TestTypes.Product> definition = duplicateSortPathDefinition();
+        PageRequest pageRequest = PageRequest.of(0, 25,
+                Sort.by(Sort.Order.asc("legacyAmount"), Sort.Order.desc("amount")));
 
         SearchPageableValidationException exception = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(
-                        PageRequest.of(0, 25,
-                                Sort.by(Sort.Order.asc("legacyAmount"), Sort.Order.desc("amount"))),
-                        definition));
+                () -> guard.pageable(pageRequest, definition));
 
         assertValidationCode(exception, SearchPageableValidationException.SORT_LIMIT_EXCEEDED);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchPageableGuardTest.java
@@ -233,11 +233,14 @@ class SearchPageableGuardTest {
         SearchPageableValidationException sizeException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> guard.pageable(invalidSize, definition));
+        SearchPolicy offsetPolicy = SearchPolicy.builder()
+                .paging(paging -> paging.maxPage(200).maxSize(200))
+                .build();
+        SearchDefinition<TestTypes.Product> offsetDefinition = definition(offsetPolicy);
+        PageRequest offsetPage = PageRequest.of(100, 101);
         SearchPageableValidationException offsetException = assertThrows(
                 SearchPageableValidationException.class,
-                () -> guard.pageable(PageRequest.of(100, 101), definition(SearchPolicy.builder()
-                        .paging(paging -> paging.maxPage(200).maxSize(200))
-                        .build())));
+                () -> guard.pageable(offsetPage, offsetDefinition));
 
         assertValidationCode(pageException, SearchPageableValidationException.PAGE_LIMIT_EXCEEDED);
         assertValidationCode(sizeException, SearchPageableValidationException.PAGE_LIMIT_EXCEEDED);

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
@@ -111,19 +111,23 @@ class SearchProtectionTest {
                 .orElseThrow();
 
         SearchProtectionContext protection = new SearchProtectionContext(policy, SearchCompilationMode.PAGE);
+        var nameField = definition.field("name").orElseThrow();
+        List<String> escapedArguments = List.of("abc\\*");
         assertDoesNotThrow(() -> protection.recordComparison(
-                definition.field("name").orElseThrow(),
+                nameField,
                 descriptor,
                 1,
-                List.of("abc\\*")));
+                escapedArguments));
 
+        SearchProtectionContext wildcardProtection = new SearchProtectionContext(policy, SearchCompilationMode.PAGE);
+        List<String> wildcardArguments = List.of("abc*");
         SearchProtectionException exception = assertThrows(
                 SearchProtectionException.class,
-                () -> new SearchProtectionContext(policy, SearchCompilationMode.PAGE).recordComparison(
-                        definition.field("name").orElseThrow(),
+                () -> wildcardProtection.recordComparison(
+                        nameField,
                         descriptor,
                         1,
-                        List.of("abc*")));
+                        wildcardArguments));
 
         assertRule(exception, "filter.like.allow-trailing-wildcard", 1, 0);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
@@ -146,19 +146,20 @@ class SearchProtectionTest {
                 .paging()
                 .build();
 
+        PageRequest pageRequest = PageRequest.of(0, 10);
         SearchProtectionException pageException = assertThrows(
                 SearchProtectionException.class,
                 () -> compiler.compile(
                         "reviewRating==5",
                         null,
-                        PageRequest.of(0, 10),
+                        pageRequest,
                         definition));
 
         assertRule(pageException, "paging.page.allow-to-many-count", 1, 0);
         assertDoesNotThrow(() -> compiler.compileSlice(
                 "reviewRating==5",
                 null,
-                PageRequest.of(0, 10),
+                pageRequest,
                 definition));
     }
 

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
@@ -195,11 +195,10 @@ class SearchProtectionTest {
                 .paging()
                 .build();
 
+        PageRequest pageRequest = PageRequest.of(0, 25, Sort.by("supplierName"));
         SearchProtectionException exception = assertThrows(
                 SearchProtectionException.class,
-                () -> guard.pageable(
-                        PageRequest.of(0, 25, Sort.by("supplierName")),
-                        definition));
+                () -> guard.pageable(pageRequest, definition));
 
         assertRule(exception, "sorting.allow-relation-sorting", 1, 0);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
@@ -215,9 +215,10 @@ class SearchProtectionTest {
                 .query(query -> query.specification(term -> Specification.unrestricted()))
                 .build();
 
+        Pageable pageable = Pageable.unpaged();
         SearchProtectionException exception = assertThrows(
                 SearchProtectionException.class,
-                () -> compiler.compile(null, "tablet", Pageable.unpaged(), definition));
+                () -> compiler.compile(null, "tablet", pageable, definition));
 
         assertRule(exception, "query.allow-with-unpaged", 1, 0);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchProtectionTest.java
@@ -6,17 +6,23 @@ import io.github.ggomarighetti.searchhelper.exception.SearchQueryValidationExcep
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.rsql.operator.DefaultRsqlOperatorDescriptors;
+import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperator;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorDescriptor;
 import io.github.ggomarighetti.searchhelper.unit.TestTypes;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.convert.ApplicationConversionService;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
+import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.BETWEEN;
 import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.EQUAL;
+import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.IGNORE_CASE_LIKE;
 import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.IN;
 import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.LIKE;
+import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.NOT_EQUAL;
+import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.NOT_IN;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -133,6 +139,254 @@ class SearchProtectionTest {
     }
 
     @Test
+    void rejectsOperatorSpecificComparisonLimits() {
+        SearchDefinition<TestTypes.Product> definition = comparisonDefinition(SearchPolicy.defaults());
+
+        SearchProtectionException notIn = assertThrows(
+                SearchProtectionException.class,
+                () -> new SearchProtectionContext(
+                        SearchPolicy.builder().filter(filter -> filter.maxNotInValues(1)).build(),
+                        SearchCompilationMode.PAGE)
+                        .recordComparison(
+                                definition.field("amount").orElseThrow(),
+                                descriptor(NOT_IN),
+                                2,
+                                List.of("10", "20")));
+        SearchProtectionException between = assertThrows(
+                SearchProtectionException.class,
+                () -> new SearchProtectionContext(
+                        SearchPolicy.builder().filter(filter -> filter.maxBetweenRanges(0)).build(),
+                        SearchCompilationMode.PAGE)
+                        .recordComparison(
+                                definition.field("amount").orElseThrow(),
+                                descriptor(BETWEEN),
+                                2,
+                                List.of("10", "20")));
+        SearchProtectionException negated = assertThrows(
+                SearchProtectionException.class,
+                () -> new SearchProtectionContext(
+                        SearchPolicy.builder().filter(filter -> filter.maxNegatedComparisons(0)).build(),
+                        SearchCompilationMode.PAGE)
+                        .recordComparison(
+                                definition.field("amount").orElseThrow(),
+                                descriptor(NOT_EQUAL),
+                                1,
+                                List.of("10")));
+
+        assertRule(notIn, "filter.max-not-in-values", 2, 1);
+        assertRule(between, "filter.max-between-ranges", 1, 0);
+        assertRule(negated, "filter.max-negated-comparisons", 1, 0);
+    }
+
+    @Test
+    void rejectsLikePolicyViolations() {
+        SearchDefinition<TestTypes.Product> definition = comparisonDefinition(SearchPolicy.defaults());
+        var nameField = definition.field("name").orElseThrow();
+
+        SearchProtectionException ignoreCase = assertThrows(
+                SearchProtectionException.class,
+                () -> context(SearchPolicy.builder()
+                        .filter(filter -> filter.like(like -> like.allowIgnoreCase(false)))
+                        .build())
+                        .recordComparison(nameField, descriptor(IGNORE_CASE_LIKE), 1, List.of("abc")));
+        SearchProtectionException length = assertThrows(
+                SearchProtectionException.class,
+                () -> context(SearchPolicy.builder()
+                        .filter(filter -> filter.like(like -> like.maxPatternLength(2)))
+                        .build())
+                        .recordComparison(nameField, descriptor(LIKE), 1, List.of("abc")));
+        SearchProtectionException wildcards = assertThrows(
+                SearchProtectionException.class,
+                () -> context(SearchPolicy.builder()
+                        .filter(filter -> filter.like(like -> like.maxWildcards(0)))
+                        .build())
+                        .recordComparison(nameField, descriptor(LIKE), 1, List.of("a*b")));
+        SearchProtectionException leading = assertThrows(
+                SearchProtectionException.class,
+                () -> context(SearchPolicy.builder()
+                        .filter(filter -> filter.like(like -> like.allowLeadingWildcard(false)))
+                        .build())
+                        .recordComparison(nameField, descriptor(LIKE), 1, List.of("*abc")));
+        SearchProtectionException contains = assertThrows(
+                SearchProtectionException.class,
+                () -> context(SearchPolicy.builder()
+                        .filter(filter -> filter.like(like -> like
+                                .allowLeadingWildcard(true)
+                                .allowTrailingWildcard(true)
+                                .allowContains(false)
+                                .maxWildcards(2)))
+                        .build())
+                        .recordComparison(nameField, descriptor(LIKE), 1, List.of("*abc*")));
+        SearchProtectionException literal = assertThrows(
+                SearchProtectionException.class,
+                () -> context(SearchPolicy.builder()
+                        .filter(filter -> filter.like(like -> like.minLiteralLength(3)))
+                        .build())
+                        .recordComparison(nameField, descriptor(LIKE), 1, List.of("a*")));
+
+        assertDoesNotThrow(() -> context(SearchPolicy.builder()
+                .filter(filter -> filter.like(like -> like.minLiteralLength(0)))
+                .build())
+                .recordComparison(nameField, descriptor(LIKE), 1, List.of("")));
+        assertRule(ignoreCase, "filter.like.allow-ignore-case", 1, 0);
+        assertRule(length, "filter.like.max-pattern-length", 3, 2);
+        assertRule(wildcards, "filter.like.max-wildcards", 1, 0);
+        assertRule(leading, "filter.like.allow-leading-wildcard", 1, 0);
+        assertRule(contains, "filter.like.allow-contains", 1, 0);
+        assertRule(literal, "filter.like.min-literal-length", 1, 3);
+    }
+
+    @Test
+    void recordsRequestStateAndRejectsCrossComponentLimits() {
+        SearchPolicy policy = SearchPolicy.builder()
+                .filter(filter -> filter.requireDistinctForToMany(true))
+                .build();
+        SearchDefinition<TestTypes.Product> definition = comparisonDefinition(policy);
+        SearchProtectionContext protection = new SearchProtectionContext(policy, SearchCompilationMode.PAGE);
+
+        assertEquals(policy, protection.policy());
+        assertEquals(SearchCompilationMode.PAGE, protection.mode());
+        protection.recordComparison(
+                definition.field("reviewRating").orElseThrow(),
+                descriptor(EQUAL),
+                1,
+                List.of("5"));
+
+        assertEquals(1, protection.joinedPaths());
+        assertEquals(1, protection.toManyPaths());
+        assertEquals(false, protection.distinct());
+
+        SearchProtectionException exception = assertThrows(SearchProtectionException.class, protection::completeFilter);
+
+        assertRule(exception, "filter.require-distinct-for-to-many", 0, 1);
+        protection.recordDistinct();
+        assertEquals(true, protection.distinct());
+        assertDoesNotThrow(protection::completeFilter);
+    }
+
+    @Test
+    void rejectsOrPageSliceSortAndQueryCombinations() {
+        SearchProtectionException heterogeneousOr = assertThrows(
+                SearchProtectionException.class,
+                () -> context(SearchPolicy.builder()
+                        .filter(filter -> filter.maxHeterogeneousOrBranches(1))
+                        .build())
+                        .recordOr(2, 2, 0));
+        SearchProtectionException sliceDisabled = assertThrows(
+                SearchProtectionException.class,
+                () -> new SearchProtectionContext(SearchPolicy.builder()
+                        .paging(paging -> paging.slice(slice -> slice.enabled(false)))
+                        .build(), SearchCompilationMode.SLICE)
+                        .recordPaging(PageRequest.of(0, 10)));
+        SearchProtectionException sliceSize = assertThrows(
+                SearchProtectionException.class,
+                () -> new SearchProtectionContext(SearchPolicy.builder()
+                        .paging(paging -> paging.slice(slice -> slice.maxSize(5)))
+                        .build(), SearchCompilationMode.SLICE)
+                        .recordPaging(PageRequest.of(0, 10)));
+        SearchProtectionException distinctCount = assertThrows(
+                SearchProtectionException.class,
+                () -> {
+                    SearchProtectionContext protection = context(SearchPolicy.builder()
+                            .paging(paging -> paging.page(page -> page.allowDistinctCount(false)))
+                            .build());
+                    protection.recordPaging(PageRequest.of(0, 10));
+                    protection.recordDistinct();
+                    protection.completeRequest();
+                });
+
+        assertRule(heterogeneousOr, "filter.max-heterogeneous-or-branches", 2, 1);
+        assertRule(sliceDisabled, "paging.slice.enabled", 1, 0);
+        assertRule(sliceSize, "paging.slice.max-size", 10, 5);
+        assertRule(distinctCount, "paging.page.allow-distinct-count", 1, 0);
+    }
+
+    @Test
+    void rejectsSortAndQueryInteractionLimits() {
+        SearchDefinition<TestTypes.Product> comparisonDefinition = comparisonDefinition(SearchPolicy.defaults());
+        SearchDefinition<Product> sortDefinition = SearchDefinition.builder()
+                .entity(Product.class)
+                .fields(fields -> fields.add("supplierName", String.class)
+                        .path("supplier.name")
+                        .sortable())
+                .build();
+        SearchProtectionException ignoreCase = assertThrows(
+                SearchProtectionException.class,
+                () -> context(SearchPolicy.builder()
+                        .sorting(sorting -> sorting.allowIgnoreCase(false))
+                        .build())
+                        .recordSort(
+                                comparisonDefinition.field("name").orElseThrow().sorting(),
+                                Sort.Order.asc("name").ignoreCase()));
+        SearchProtectionException nullHandling = assertThrows(
+                SearchProtectionException.class,
+                () -> context(SearchPolicy.builder()
+                        .sorting(sorting -> sorting.allowNullHandling(false))
+                        .build())
+                        .recordSort(
+                                comparisonDefinition.field("name").orElseThrow().sorting(),
+                                Sort.Order.asc("name").nullsLast()));
+        SearchProtectionException relationOrders = assertThrows(
+                SearchProtectionException.class,
+                () -> context(SearchPolicy.builder()
+                        .sorting(sorting -> sorting.maxRelationOrders(0))
+                        .build())
+                        .recordSort(
+                                sortDefinition.field("supplierName").orElseThrow().sorting(),
+                                Sort.Order.asc("supplierName")));
+        SearchProtectionException queryWithToMany = assertThrows(
+                SearchProtectionException.class,
+                () -> {
+                    SearchPolicy policy = SearchPolicy.builder()
+                            .query(query -> query.allowWithToManyFilter(false))
+                            .build();
+                    SearchProtectionContext protection = context(policy);
+                    protection.recordQuery("tablet");
+                    protection.recordComparison(
+                            comparisonDefinition(policy).field("reviewRating").orElseThrow(),
+                            descriptor(EQUAL),
+                            1,
+                            List.of("5"));
+                    protection.completeRequest();
+                });
+        SearchProtectionException queryWithRelationSort = assertThrows(
+                SearchProtectionException.class,
+                () -> {
+                    SearchProtectionContext protection = context(SearchPolicy.builder()
+                            .query(query -> query.allowWithRelationSort(false))
+                            .build());
+                    protection.recordQuery("tablet");
+                    protection.recordSort(
+                            sortDefinition.field("supplierName").orElseThrow().sorting(),
+                            Sort.Order.asc("supplierName"));
+                    protection.completeRequest();
+                });
+
+        assertRule(ignoreCase, "sorting.allow-ignore-case", 1, 0);
+        assertRule(nullHandling, "sorting.allow-null-handling", 1, 0);
+        assertRule(relationOrders, "sorting.max-relation-orders", 1, 0);
+        assertRule(queryWithToMany, "query.allow-with-to-many-filter", 1, 0);
+        assertRule(queryWithRelationSort, "query.allow-with-relation-sort", 1, 0);
+    }
+
+    @Test
+    void rejectsQueryLengthLimitsAndIgnoresAbsentQuery() {
+        SearchProtectionContext protection = context(SearchPolicy.defaults());
+
+        assertDoesNotThrow(() -> protection.recordQuery(null));
+
+        SearchProtectionException tooLong = assertThrows(
+                SearchProtectionException.class,
+                () -> context(SearchPolicy.builder().query(query -> query.maxLength(3)).build()).recordQuery("abcd"));
+        SearchProtectionException tooShort = assertThrows(
+                SearchProtectionException.class,
+                () -> context(SearchPolicy.builder().query(query -> query.minLength(3)).build()).recordQuery("ab"));
+
+        assertRule(tooLong, "query.max-length", 4, 3);
+        assertRule(tooShort, "query.min-length", 2, 3);
+    }
+
+    @Test
     void pageModeCanRejectToManyCountWhileSliceModeAcceptsSameShape() {
         SearchPolicy policy = SearchPolicy.builder()
                 .paging(paging -> paging.page(page -> page.allowToManyCount(false)))
@@ -246,6 +500,35 @@ class SearchProtectionTest {
                                 org.springframework.boot.convert.ApplicationConversionService.getSharedInstance())
                         .build(),
                 policy);
+    }
+
+    private static SearchProtectionContext context(SearchPolicy policy) {
+        return new SearchProtectionContext(policy, SearchCompilationMode.PAGE);
+    }
+
+    private static RsqlOperatorDescriptor descriptor(RsqlOperator operator) {
+        return DefaultRsqlOperatorDescriptors.all().stream()
+                .filter(candidate -> operator.equals(candidate.operator()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private static SearchDefinition<TestTypes.Product> comparisonDefinition(SearchPolicy policy) {
+        return SearchDefinition.builder(policy)
+                .entity(TestTypes.Product.class)
+                .fields(fields -> {
+                    fields.add("amount", java.math.BigDecimal.class)
+                            .path("price")
+                            .filterable(filter -> filter.allow(EQUAL))
+                            .sortable();
+                    fields.add("name", String.class)
+                            .filterable(filter -> filter.allow(LIKE))
+                            .sortable();
+                    fields.add("reviewRating", Integer.class)
+                            .path("reviews.rating")
+                            .filterable(filter -> filter.allow(EQUAL));
+                })
+                .build();
     }
 
     private static void assertRule(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
@@ -3,7 +3,6 @@ package io.github.ggomarighetti.searchhelper.compile;
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.exception.SearchQueryValidationException;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.unit.TestTypes;
 import java.util.concurrent.atomic.AtomicReference;
 import org.hibernate.validator.cfg.defs.PatternDef;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
@@ -24,9 +24,10 @@ class SearchQueryGuardTest {
 
     @Test
     void rejectsQueryWhenDefinitionDoesNotDeclareQuery() {
+        SearchDefinition<TestTypes.Product> definition = definitionWithoutQuery();
         SearchQueryValidationException exception = assertThrows(
                 SearchQueryValidationException.class,
-                () -> guard.specification("tablets", definitionWithoutQuery()));
+                () -> guard.specification("tablets", definition));
 
         assertValidationCode(exception, SearchQueryValidationException.QUERY_RULES_FORBIDDEN);
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
@@ -3,6 +3,7 @@ package io.github.ggomarighetti.searchhelper.compile;
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.exception.SearchQueryValidationException;
+import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.unit.TestTypes;
 import java.util.concurrent.atomic.AtomicReference;
 import org.hibernate.validator.cfg.defs.PatternDef;
@@ -10,6 +11,7 @@ import org.hibernate.validator.cfg.defs.SizeDef;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.data.jpa.domain.Specification.unrestricted;
 
@@ -28,6 +30,23 @@ class SearchQueryGuardTest {
         SearchQueryValidationException exception = assertThrows(
                 SearchQueryValidationException.class,
                 () -> guard.specification("tablets", definition));
+
+        assertValidationCode(exception, SearchQueryValidationException.QUERY_RULES_FORBIDDEN);
+    }
+
+    @Test
+    void rejectsQueryWhenPolicyDisablesQuerying() {
+        SearchQueryGuard disabledGuard = new SearchQueryGuard(SearchPolicy.builder()
+                .query(query -> query.enabled(false))
+                .build());
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("name", String.class))
+                .query(query -> query.specification(term -> unrestricted()))
+                .build();
+
+        SearchQueryValidationException exception = assertThrows(
+                SearchQueryValidationException.class,
+                () -> disabledGuard.specification("tablet", definition));
 
         assertValidationCode(exception, SearchQueryValidationException.QUERY_RULES_FORBIDDEN);
     }
@@ -135,6 +154,26 @@ class SearchQueryGuardTest {
                 () -> specification.toPredicate(null, null, null));
 
         assertValidationCode(exception, SearchQueryValidationException.QUERY_RULES_FORBIDDEN);
+    }
+
+    @Test
+    void preservesDeferredQueryValidationFailures() {
+        SearchQueryValidationException expected = new SearchQueryValidationException(
+                SearchQueryValidationException.QUERY_RULES_FORBIDDEN,
+                "query rejected");
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("name", String.class))
+                .query(query -> query.specification(term -> (root, criteria, builder) -> {
+                    throw expected;
+                }))
+                .build();
+
+        var specification = guard.specification("tablet", definition);
+        SearchQueryValidationException actual = assertThrows(
+                SearchQueryValidationException.class,
+                () -> specification.toPredicate(null, null, null));
+
+        assertSame(expected, actual);
     }
 
     @Test

--- a/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/compile/SearchQueryGuardTest.java
@@ -85,7 +85,8 @@ class SearchQueryGuardTest {
         assertEquals(
                 "{jakarta.validation.constraints.Pattern.message}",
                 patternException.violations().get(0).messageTemplate());
-        assertThrows(UnsupportedOperationException.class, () -> sizeException.violations().clear());
+        var violations = sizeException.violations();
+        assertThrows(UnsupportedOperationException.class, violations::clear);
     }
 
     @Test

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchFixtures.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchFixtures.java
@@ -3,7 +3,6 @@ package io.github.ggomarighetti.searchhelper.integration;
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSpecifications;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
-import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -233,12 +233,13 @@ class ProductSearchPostgresIT {
         assertRsqlCode("status==PUBLISHED", definition, RsqlFilterValidationException.RULES_FORBIDDEN);
         assertRsqlCode("publicId==not-a-uuid", definition, RsqlFilterValidationException.RULES_FORBIDDEN);
 
+        PageRequest unsafeSort = PageRequest.of(0, 10, Sort.by("internalCost"));
         SearchPageableValidationException sortException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> compiler.compile(
                         null,
                         null,
-                        PageRequest.of(0, 10, Sort.by("internalCost")),
+                        unsafeSort,
                         definition));
         SearchPageableValidationException pageException = assertThrows(
                 SearchPageableValidationException.class,

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -265,10 +265,11 @@ class ProductSearchPostgresIT {
                 .fields(fields -> fields.add("displayName", String.class)
                         .filterable(filter -> filter.allow(EQUAL)))
                 .build();
+        JpaSearchDefinitionValidator validator = jpaDefinitionValidator();
 
         SearchDefinitionValidationException exception = assertThrows(
                 SearchDefinitionValidationException.class,
-                () -> jpaDefinitionValidator().validate(definition));
+                () -> validator.validate(definition));
 
         assertEquals(SearchDefinitionValidationException.JPA_PATH_UNRESOLVED, exception.code());
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -241,12 +241,13 @@ class ProductSearchPostgresIT {
                         null,
                         unsafeSort,
                         definition));
+        PageRequest unsafePage = PageRequest.of(0, 51);
         SearchPageableValidationException pageException = assertThrows(
                 SearchPageableValidationException.class,
                 () -> compiler.compile(
                         null,
                         null,
-                        PageRequest.of(0, 51),
+                        unsafePage,
                         definition));
 
         assertEquals(SearchPageableValidationException.SORT_RULES_FORBIDDEN, sortException.code());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -40,7 +40,6 @@ import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.E
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @DataJpaTest(
         showSql = false,

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -294,9 +294,10 @@ class ProductSearchPostgresIT {
             String filter,
             SearchDefinition<Product> definition,
             String expectedCode) {
+        PageRequest pageRequest = PageRequest.of(0, 1);
         RsqlFilterValidationException exception = assertThrows(
                 RsqlFilterValidationException.class,
-                () -> compiler.compile(filter, null, PageRequest.of(0, 1), definition));
+                () -> compiler.compile(filter, null, pageRequest, definition));
 
         assertEquals(expectedCode, exception.code());
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -40,7 +40,6 @@ import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.E
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.springframework.data.domain.Sort.Direction.ASC;
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
 @DataJpaTest(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -8,7 +8,6 @@ import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidation
 import io.github.ggomarighetti.searchhelper.exception.SearchPageableValidationException;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductRepository;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSeeder.Catalog;
-import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSpecifications;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.integration.postgres.PostgresTestEnvironment;
 import io.github.ggomarighetti.searchhelper.jpa.JpaSearchDefinitionValidator;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
-import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -19,7 +19,6 @@ import org.springframework.boot.convert.ApplicationConversionService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -7,7 +7,6 @@ import io.github.ggomarighetti.searchhelper.exception.RsqlFilterValidationExcept
 import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidationException;
 import io.github.ggomarighetti.searchhelper.exception.SearchPageableValidationException;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductRepository;
-import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSeeder;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSeeder.Catalog;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSpecifications;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
-import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresIT.java
@@ -30,7 +30,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresPlanIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/ProductSearchPostgresPlanIT.java
@@ -5,7 +5,6 @@ import io.github.ggomarighetti.searchhelper.compile.CompiledSearch;
 import io.github.ggomarighetti.searchhelper.compile.SearchCompiler;
 import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductRepository;
-import io.github.ggomarighetti.searchhelper.integration.bench.dao.ProductSpecifications;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.integration.postgres.PostgresExplain;
 import io.github.ggomarighetti.searchhelper.integration.postgres.PostgresPlan;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/SearchDefinitionRuntimeValidationPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/SearchDefinitionRuntimeValidationPostgresIT.java
@@ -57,11 +57,12 @@ class SearchDefinitionRuntimeValidationPostgresIT {
                 .run(context -> {
                     SearchCompiler compiler = context.getBean(SearchCompiler.class);
                     SearchDefinition<?> definition = context.getBean(SearchDefinition.class);
+                    PageRequest pageRequest = PageRequest.of(0, 20);
 
                     assertThatThrownBy(() -> compiler.compile(
                                     "displayName==Laptop",
                                     null,
-                                    PageRequest.of(0, 20),
+                                    pageRequest,
                                     definition))
                             .isInstanceOf(SearchDefinitionValidationException.class)
                             .hasMessageContaining("displayName")

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/SearchDefinitionRuntimeValidationPostgresIT.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/SearchDefinitionRuntimeValidationPostgresIT.java
@@ -78,11 +78,12 @@ class SearchDefinitionRuntimeValidationPostgresIT {
                 .run(context -> {
                     SearchCompiler compiler = context.getBean(SearchCompiler.class);
                     SearchDefinition<?> definition = context.getBean(SearchDefinition.class);
+                    PageRequest pageRequest = PageRequest.of(0, 20);
 
                     assertThatThrownBy(() -> compiler.compile(
                                     null,
                                     null,
-                                    PageRequest.of(0, 20),
+                                    pageRequest,
                                     definition))
                             .isInstanceOf(SearchDefinitionValidationException.class)
                             .hasMessageContaining("displayName")

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
@@ -1,6 +1,5 @@
 package io.github.ggomarighetti.searchhelper.integration.postgres;
 
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Category;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Review;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Supplier;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
@@ -1,6 +1,5 @@
 package io.github.ggomarighetti.searchhelper.integration.postgres;
 
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Review;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Supplier;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
@@ -1,6 +1,5 @@
 package io.github.ggomarighetti.searchhelper.integration.postgres;
 
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Supplier;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.sql.PreparedStatement;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/integration/postgres/ProductPlanSeeder.java
@@ -1,6 +1,5 @@
 package io.github.ggomarighetti.searchhelper.integration.postgres;
 
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Review;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Supplier;
 import java.math.BigDecimal;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/property/SearchPropertyFixtures.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/property/SearchPropertyFixtures.java
@@ -15,6 +15,7 @@ import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Status;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
+import io.github.ggomarighetti.searchhelper.sort.SearchSorting;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Map;
@@ -120,7 +121,7 @@ public final class SearchPropertyFixtures {
                             .sortable(sort -> sort.allow(Sort.Direction.DESC));
                     fields.add("supplierName", String.class)
                             .path("supplier.name")
-                            .sortable(sort -> sort.allowIgnoreCase());
+                            .sortable(SearchSorting.Builder::allowIgnoreCase);
                     fields.add("status", Status.class);
                 })
                 .paging()

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
@@ -107,13 +107,14 @@ class DefaultFilterOperatorsTest {
 
     @Test
     void filteringWithDefaultsCannotDenyTheEntireProfile() {
+        var builder = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("active", Boolean.class)
+                        .filterable(filter -> filter.withDefaults().deny(EQUAL, NOT_EQUAL)));
+
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
-                () -> SearchDefinition.builder()
-                        .entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("active", Boolean.class)
-                                .filterable(filter -> filter.withDefaults().deny(EQUAL, NOT_EQUAL)))
-                        .build());
+                builder::build);
 
         assertEquals(
                 "selector 'active' filtering must declare at least one allowed operator",

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
@@ -31,6 +31,7 @@ class DefaultFilterOperatorsTest {
         assertContains(String.class, EQUAL, NOT_EQUAL, IN, LIKE, IGNORE_CASE_LIKE);
         assertContains(BigDecimal.class, EQUAL, IN, GREATER_THAN_OR_EQUAL, BETWEEN);
         assertContains(int.class, EQUAL, IN, GREATER_THAN_OR_EQUAL, BETWEEN);
+        assertContains(char.class, EQUAL, NOT_EQUAL, IN);
         assertContains(LocalDate.class, EQUAL, IN, GREATER_THAN_OR_EQUAL, BETWEEN);
         assertContains(DataSize.class, EQUAL, IN, GREATER_THAN_OR_EQUAL, BETWEEN);
         assertEquals(Set.of(EQUAL, NOT_EQUAL), DefaultFilterOperators.forType(Boolean.class));
@@ -186,6 +187,12 @@ class DefaultFilterOperatorsTest {
         Set<RsqlOperator> operators = DefaultFilterOperators.forType(String.class);
 
         assertThrows(UnsupportedOperationException.class, operators::clear);
+    }
+
+    @Test
+    void reportsWhetherDefaultProfilesExist() {
+        assertTrue(DefaultFilterOperators.supports(String.class));
+        assertFalse(DefaultFilterOperators.supports(TestTypes.Owner.class));
     }
 
     private static void assertContains(Class<?> type, RsqlOperator... expected) {

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
@@ -152,12 +152,13 @@ class DefaultFilterOperatorsTest {
 
     @Test
     void reportsUnsupportedDefaultProfilesAsDefinitionErrors() {
+        var builder = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("owner", TestTypes.Owner.class).filterable());
+
         SearchDefinitionValidationException exception = assertThrows(
                 SearchDefinitionValidationException.class,
-                () -> SearchDefinition.builder()
-                        .entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("owner", TestTypes.Owner.class).filterable())
-                        .build());
+                builder::build);
 
         assertEquals(
                 SearchDefinitionValidationException.DEFAULT_OPERATORS_UNSUPPORTED_TYPE,

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
@@ -182,7 +182,7 @@ class DefaultFilterOperatorsTest {
     void returnedProfilesAreImmutable() {
         Set<RsqlOperator> operators = DefaultFilterOperators.forType(String.class);
 
-        assertThrows(UnsupportedOperationException.class, () -> operators.clear());
+        assertThrows(UnsupportedOperationException.class, operators::clear);
     }
 
     private static void assertContains(Class<?> type, RsqlOperator... expected) {

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/DefaultFilterOperatorsTest.java
@@ -167,13 +167,14 @@ class DefaultFilterOperatorsTest {
 
     @Test
     void filteringWithDefaultsReportsUnsupportedProfilesAsDefinitionErrors() {
+        var builder = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("owner", TestTypes.Owner.class)
+                        .filterable(filter -> filter.withDefaults().allow(IS_NULL)));
+
         SearchDefinitionValidationException exception = assertThrows(
                 SearchDefinitionValidationException.class,
-                () -> SearchDefinition.builder()
-                        .entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("owner", TestTypes.Owner.class)
-                                .filterable(filter -> filter.withDefaults().allow(IS_NULL)))
-                        .build());
+                builder::build);
 
         assertEquals(
                 SearchDefinitionValidationException.DEFAULT_OPERATORS_UNSUPPORTED_TYPE,

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/JpaSearchDefinitionValidatorTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/JpaSearchDefinitionValidatorTest.java
@@ -1,0 +1,187 @@
+package io.github.ggomarighetti.searchhelper.unit;
+
+import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
+import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidationException;
+import io.github.ggomarighetti.searchhelper.jpa.JpaSearchDefinitionValidator;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.ManagedType;
+import jakarta.persistence.metamodel.Metamodel;
+import jakarta.persistence.metamodel.PluralAttribute;
+import jakarta.persistence.metamodel.Type;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.EQUAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JpaSearchDefinitionValidatorTest {
+    @Test
+    void rejectsEntityMissingFromMetamodel() {
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class)
+                        .filterable(filter -> filter.allow(EQUAL)))
+                .build();
+
+        SearchDefinitionValidationException exception = assertThrows(
+                SearchDefinitionValidationException.class,
+                () -> validator(Map.of()).validate(definition));
+
+        assertEquals(SearchDefinitionValidationException.JPA_PATH_UNRESOLVED, exception.code());
+    }
+
+    @Test
+    void rejectsJpaAttributeTypeMismatch() {
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class)
+                        .filterable(filter -> filter.allow(EQUAL)))
+                .build();
+        ManagedType<?> product = managedType(Map.of("email", attribute(Integer.class, false)));
+
+        SearchDefinitionValidationException exception = assertThrows(
+                SearchDefinitionValidationException.class,
+                () -> validator(Map.of(TestTypes.Product.class, product)).validate(definition));
+
+        assertEquals(SearchDefinitionValidationException.JPA_PATH_UNRESOLVED, exception.code());
+    }
+
+    @Test
+    void rejectsCollectionAttributeThatIsNotPluralAttribute() {
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("reviewRating", Integer.class)
+                        .path("reviews.rating")
+                        .filterable(filter -> filter.allow(EQUAL)))
+                .build();
+        ManagedType<?> product = managedType(Map.of("reviews", attribute(List.class, true)));
+
+        SearchDefinitionValidationException exception = assertThrows(
+                SearchDefinitionValidationException.class,
+                () -> validator(Map.of(TestTypes.Product.class, product)).validate(definition));
+
+        assertEquals(SearchDefinitionValidationException.JPA_PATH_UNRESOLVED, exception.code());
+    }
+
+    @Test
+    void rejectsNestedTypeMissingFromMetamodel() {
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("customerName", String.class)
+                        .path("customer.name")
+                        .sortable())
+                .build();
+        ManagedType<?> product = managedType(Map.of("customer", attribute(TestTypes.Customer.class, false)));
+
+        SearchDefinitionValidationException exception = assertThrows(
+                SearchDefinitionValidationException.class,
+                () -> validator(Map.of(TestTypes.Product.class, product)).validate(definition));
+
+        assertEquals(SearchDefinitionValidationException.JPA_PATH_UNRESOLVED, exception.code());
+    }
+
+    @Test
+    void resolvesPluralAttributesThroughElementType() {
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("reviewRating", Integer.class)
+                        .path("reviews.rating")
+                        .filterable(filter -> filter.allow(EQUAL)))
+                .build();
+        ManagedType<?> product = managedType(Map.of("reviews", pluralAttribute(TestTypes.Review.class)));
+        ManagedType<?> review = managedType(Map.of("rating", attribute(int.class, false)));
+
+        validator(Map.of(TestTypes.Product.class, product, TestTypes.Review.class, review)).validate(definition);
+    }
+
+    private static JpaSearchDefinitionValidator validator(Map<Class<?>, ManagedType<?>> managedTypes) {
+        Metamodel metamodel = proxy(Metamodel.class, (proxy, method, args) -> {
+            if (method.getName().equals("managedType")) {
+                ManagedType<?> managedType = managedTypes.get(args[0]);
+                if (managedType == null) {
+                    throw new IllegalArgumentException("not managed");
+                }
+                return managedType;
+            }
+            throw unsupported(method);
+        });
+        EntityManagerFactory entityManagerFactory = proxy(EntityManagerFactory.class, (proxy, method, args) -> {
+            if (method.getName().equals("getMetamodel")) {
+                return metamodel;
+            }
+            throw unsupported(method);
+        });
+        return new JpaSearchDefinitionValidator(entityManagerFactory);
+    }
+
+    private static ManagedType<?> managedType(Map<String, Attribute<?, ?>> attributes) {
+        return proxy(ManagedType.class, (proxy, method, args) -> {
+            if (method.getName().equals("getAttribute")) {
+                Attribute<?, ?> attribute = attributes.get(args[0]);
+                if (attribute == null) {
+                    throw new IllegalArgumentException("missing attribute");
+                }
+                return attribute;
+            }
+            throw unsupported(method);
+        });
+    }
+
+    private static Attribute<?, ?> attribute(Class<?> javaType, boolean collection) {
+        return proxy(Attribute.class, (proxy, method, args) -> {
+            return switch (method.getName()) {
+                case "getJavaType" -> javaType;
+                case "isCollection" -> collection;
+                default -> throw unsupported(method);
+            };
+        });
+    }
+
+    private static PluralAttribute<?, ?, ?> pluralAttribute(Class<?> elementType) {
+        Type<?> type = proxy(Type.class, (proxy, method, args) -> {
+            if (method.getName().equals("getJavaType")) {
+                return elementType;
+            }
+            throw unsupported(method);
+        });
+        return proxy(PluralAttribute.class, (proxy, method, args) -> {
+            return switch (method.getName()) {
+                case "getJavaType" -> List.class;
+                case "isCollection" -> true;
+                case "getElementType" -> type;
+                default -> throw unsupported(method);
+            };
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type, InvocationHandler handler) {
+        return (T) Proxy.newProxyInstance(
+                type.getClassLoader(),
+                new Class<?>[] {type},
+                (proxy, method, args) -> {
+                    if (method.getDeclaringClass().equals(Object.class)) {
+                        return objectMethod(proxy, method, args);
+                    }
+                    return handler.invoke(proxy, method, args);
+                });
+    }
+
+    private static Object objectMethod(Object proxy, Method method, Object[] args) {
+        return switch (method.getName()) {
+            case "toString" -> proxy.getClass().getInterfaces()[0].getSimpleName() + " proxy";
+            case "hashCode" -> System.identityHashCode(proxy);
+            case "equals" -> proxy == args[0];
+            default -> throw unsupported(method);
+        };
+    }
+
+    private static UnsupportedOperationException unsupported(Method method) {
+        return new UnsupportedOperationException(method.toGenericString());
+    }
+}

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/RsqlEngineCoverageTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/RsqlEngineCoverageTest.java
@@ -1,0 +1,142 @@
+package io.github.ggomarighetti.searchhelper.unit;
+
+import cz.jirutka.rsql.parser.RSQLParser;
+import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
+import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidationException;
+import io.github.ggomarighetti.searchhelper.rsql.RsqlCompilationRequest;
+import io.github.ggomarighetti.searchhelper.rsql.SearchRsqlEngine;
+import io.github.ggomarighetti.searchhelper.rsql.backend.RsqlBackendAdapter;
+import io.github.ggomarighetti.searchhelper.rsql.backend.perplexhub.PerplexhubRsqlBackendAdapter;
+import io.github.ggomarighetti.searchhelper.rsql.backend.perplexhub.PerplexhubRsqlBackendOptions;
+import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperator;
+import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorDescriptor;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.data.jpa.domain.Specification;
+import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.EQUAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RsqlEngineCoverageTest {
+    private static final RsqlOperator CUSTOM = RsqlOperator.of("custom");
+
+    @Test
+    void builderAcceptsBulkOperatorsParserFactoryBackendAndConversionService() {
+        RsqlOperatorDescriptor descriptor = RsqlOperatorDescriptor.of(CUSTOM, "=custom=");
+        RsqlBackendAdapter backend = new NoOpBackend();
+        SearchRsqlEngine engine = SearchRsqlEngine.builder()
+                .operators(List.of(descriptor))
+                .parserFactory(operators -> new RSQLParser(operators.parserOperators()))
+                .backend(backend)
+                .conversionService(ApplicationConversionService.getSharedInstance())
+                .build();
+
+        assertTrue(engine.operators().descriptor(CUSTOM).isPresent());
+        assertNotNull(engine.parse("email==value"));
+        assertThrows(NullPointerException.class, () -> SearchRsqlEngine.builder().operators(null));
+        assertThrows(NullPointerException.class, () -> SearchRsqlEngine.builder().parserFactory(null));
+    }
+
+    @Test
+    void parsedAstExposesNormalizedComparisonsForLogicalExpressions() {
+        var ast = SearchRsqlEngine.defaults().parse("email==a;name==b");
+
+        assertEquals(2, ast.comparisons().size());
+        assertEquals(EQUAL, ast.comparisons().get(0).operator());
+    }
+
+    @Test
+    void validateRejectsUnregisteredOperatorsAndTypeMismatches() {
+        SearchDefinition<TestTypes.Product> unregistered = definition(CUSTOM, String.class);
+        SearchDefinition<TestTypes.Product> mismatch = definition(CUSTOM, Integer.class);
+        SearchRsqlEngine mismatchEngine = SearchRsqlEngine.builder()
+                .operator(RsqlOperatorDescriptor.builder(CUSTOM)
+                        .symbol("=custom=")
+                        .argumentType(String.class)
+                        .build())
+                .backend(new NoOpBackend())
+                .build();
+
+        SearchDefinitionValidationException missing = assertThrows(
+                SearchDefinitionValidationException.class,
+                () -> SearchRsqlEngine.defaults().validate(unregistered));
+        SearchDefinitionValidationException typeMismatch = assertThrows(
+                SearchDefinitionValidationException.class,
+                () -> mismatchEngine.validate(mismatch));
+
+        assertEquals(SearchDefinitionValidationException.RSQL_OPERATOR_NOT_REGISTERED, missing.code());
+        assertEquals(SearchDefinitionValidationException.RSQL_OPERATOR_TYPE_MISMATCH, typeMismatch.code());
+    }
+
+    @Test
+    void validateRejectsOperatorsThatCannotBeConvertedFromString() {
+        SearchDefinition<TestTypes.Product> definition = definition(CUSTOM, NoConversion.class);
+        SearchRsqlEngine engine = SearchRsqlEngine.builder()
+                .operator(RsqlOperatorDescriptor.builder(CUSTOM)
+                        .symbol("=custom=")
+                        .argumentType(NoConversion.class)
+                        .build())
+                .backend(new NoOpBackend())
+                .build();
+
+        SearchDefinitionValidationException exception = assertThrows(
+                SearchDefinitionValidationException.class,
+                () -> engine.validate(definition));
+
+        assertEquals(SearchDefinitionValidationException.RSQL_OPERATOR_TYPE_MISMATCH, exception.code());
+    }
+
+    @Test
+    void perplexhubOptionsCustomizeAndBackendRequiresCustomArgumentTypes() {
+        PerplexhubRsqlBackendOptions options = PerplexhubRsqlBackendOptions.builder()
+                .customize(builder -> builder
+                        .strictEquality(false)
+                        .likeEscapeCharacter('\\'))
+                .build();
+        RsqlOperatorDescriptor descriptor = RsqlOperatorDescriptor.builder(CUSTOM)
+                .symbol("=custom=")
+                .jpaPredicate(context -> null)
+                .build();
+        SearchRsqlEngine engine = SearchRsqlEngine.builder()
+                .operator(descriptor)
+                .backend(new NoOpBackend())
+                .build();
+        SearchDefinition<TestTypes.Product> definition = definition(CUSTOM, String.class);
+
+        assertFalse(options.strictEquality());
+        assertEquals('\\', options.likeEscapeCharacter());
+        assertThrows(NullPointerException.class, () -> PerplexhubRsqlBackendOptions.builder().customize(null));
+
+        SearchDefinitionValidationException exception = assertThrows(
+                SearchDefinitionValidationException.class,
+                () -> new PerplexhubRsqlBackendAdapter(options).validate(engine, definition));
+
+        assertEquals(SearchDefinitionValidationException.RSQL_OPERATOR_TYPE_MISMATCH, exception.code());
+    }
+
+    private static <A> SearchDefinition<TestTypes.Product> definition(RsqlOperator operator, Class<A> argumentType) {
+        return SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class)
+                        .filterable(filter -> filter.allow(operator, argumentType, customizer -> {})))
+                .build();
+    }
+
+    private static final class NoConversion implements Comparable<NoConversion> {
+        @Override
+        public int compareTo(NoConversion other) {
+            return 0;
+        }
+    }
+
+    private static final class NoOpBackend implements RsqlBackendAdapter {
+        @Override
+        public <T> Specification<T> compile(RsqlCompilationRequest<T> request) {
+            return (root, query, criteriaBuilder) -> criteriaBuilder.conjunction();
+        }
+    }
+}

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -197,14 +197,16 @@ class SearchCompilerTest {
                         .conversionService(ApplicationConversionService.getSharedInstance())
                         .build(),
                 policy);
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        SearchDefinition<TestTypes.Product> definition = definition(new AtomicReference<>());
 
         assertThrows(
                 SearchProtectionException.class,
                 () -> customCompiler.compile(
                         "taxId=in=(1,2)",
                         null,
-                        PageRequest.of(0, 10),
-                definition(new AtomicReference<>())));
+                        pageRequest,
+                        definition));
     }
 
     @Test

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -5,7 +5,6 @@ import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.compile.CompiledSearch;
 import io.github.ggomarighetti.searchhelper.compile.SearchCompiler;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
-import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
 import io.github.ggomarighetti.searchhelper.rsql.SearchRsqlEngine;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Predicate;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -139,8 +139,8 @@ class SearchCompilerTest {
                 () -> compiler.compile(
                         null,
                         null,
-                        PageRequest.of(0, 10),
-                        emptyDefinition(),
+                        pageRequest,
+                        definition,
                         (Specification<TestTypes.Product>) null));
 
         assertEquals("specifications must not be null", arrayException.getMessage());

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -38,6 +38,13 @@ class SearchCompilerTest {
     private final SearchCompiler compiler = new SearchCompiler();
 
     @Test
+    void constructsWithExplicitPolicy() {
+        SearchCompiler customCompiler = new SearchCompiler(SearchPolicy.defaults());
+
+        assertNotNull(customCompiler);
+    }
+
+    @Test
     void combinesRsqlFilterAndQuerySpecification() {
         AtomicReference<String> capturedQuery = new AtomicReference<>();
         SearchDefinition<TestTypes.Product> definition = definition(capturedQuery);

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -243,7 +243,7 @@ class SearchCompilerTest {
                 () -> customCompiler.compile(null, null, pageRequest, definition));
         assertThrows(
                 IllegalStateException.class,
-                () -> customCompiler.compile(null, null, PageRequest.of(0, 10), definition));
+                () -> customCompiler.compile(null, null, pageRequest, definition));
 
         assertEquals(2, validations.get());
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -236,10 +236,11 @@ class SearchCompilerTest {
                     throw new IllegalStateException("invalid definition");
                 }));
         SearchDefinition<TestTypes.Product> definition = emptyDefinition();
+        PageRequest pageRequest = PageRequest.of(0, 10);
 
         assertThrows(
                 IllegalStateException.class,
-                () -> customCompiler.compile(null, null, PageRequest.of(0, 10), definition));
+                () -> customCompiler.compile(null, null, pageRequest, definition));
         assertThrows(
                 IllegalStateException.class,
                 () -> customCompiler.compile(null, null, PageRequest.of(0, 10), definition));

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -128,10 +128,12 @@ class SearchCompilerTest {
     void rejectsNullApplicationSpecifications() {
         @SuppressWarnings("unchecked")
         Specification<TestTypes.Product>[] nullSpecifications = null;
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        SearchDefinition<TestTypes.Product> definition = emptyDefinition();
 
         NullPointerException arrayException = assertThrows(
                 NullPointerException.class,
-                () -> compiler.compile(null, null, PageRequest.of(0, 10), emptyDefinition(), nullSpecifications));
+                () -> compiler.compile(null, null, pageRequest, definition, nullSpecifications));
         NullPointerException elementException = assertThrows(
                 NullPointerException.class,
                 () -> compiler.compile(

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchCompilerTest.java
@@ -4,7 +4,6 @@ import io.github.ggomarighetti.searchhelper.definition.SearchDefinition;
 import io.github.ggomarighetti.searchhelper.exception.SearchProtectionException;
 import io.github.ggomarighetti.searchhelper.compile.CompiledSearch;
 import io.github.ggomarighetti.searchhelper.compile.SearchCompiler;
-import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
 import io.github.ggomarighetti.searchhelper.rsql.SearchRsqlEngine;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -506,12 +506,13 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsPathDeeperThanSafetyLimitByDefault() {
-        SearchDefinitionValidationException exception = assertThrows(SearchDefinitionValidationException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("countryCode", String.class)
-                                .path("customer.region.country.code")
-                                .sortable())
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("countryCode", String.class)
+                        .path("customer.region.country.code")
+                        .sortable());
+
+        SearchDefinitionValidationException exception =
+                assertThrows(SearchDefinitionValidationException.class, builder::build);
 
         assertEquals(SearchDefinitionValidationException.PATH_LIMIT_EXCEEDED, exception.code());
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -6,7 +6,6 @@ import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidation
 import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.query.SearchQuery;
-import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
 import io.github.ggomarighetti.searchhelper.sort.SearchSorting;
 import java.math.BigDecimal;
 import java.util.Set;

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -542,12 +542,12 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsNestedCollectionValuedPathWhenElementTypeCannotBeResolved() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("reviewRating", Integer.class)
-                                .path("rawReviews.rating")
-                                .filterable(filter -> filter.allow(EQUAL)))
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("reviewRating", Integer.class)
+                        .path("rawReviews.rating")
+                        .filterable(filter -> filter.allow(EQUAL)));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertTrue(exception.getMessage().contains("could not be resolved"));
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -71,12 +71,11 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsSubtypeOutsideEntityHierarchy() {
-        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
-                .fields(fields -> fields.add("expiresAt", java.time.Instant.class)
-                        .subtype(String.class)
-                        .filterable(filter -> filter.allow(EQUAL)));
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class);
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> addInvalidSubtypeField(builder));
 
         assertTrue(exception.getMessage().contains("must extend entity"));
     }
@@ -574,5 +573,11 @@ class SearchDefinitionTest {
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertTrue(exception.getMessage().contains("ignoreCase sorting requires a CharSequence path"));
+    }
+
+    private static void addInvalidSubtypeField(SearchDefinition.Builder<TestTypes.Product> builder) {
+        builder.fields(fields -> fields.add("expiresAt", java.time.Instant.class)
+                .subtype(String.class)
+                .filterable(filter -> filter.allow(EQUAL)));
     }
 }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -392,15 +392,16 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsDuplicatedQueryDeclaration() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("email", String.class))
-                        .query(query -> query.specification(term ->
-                                (root, criteria, builder) -> builder.conjunction()))
-                        .query(SearchQuery.<TestTypes.Product>builder()
-                                .specification(term -> (root, criteria, builder) -> builder.conjunction())
-                                .build())
-                        .build());
+        SearchQuery<TestTypes.Product> query = SearchQuery.<TestTypes.Product>builder()
+                .specification(term -> (root, criteria, builder) -> builder.conjunction())
+                .build();
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class))
+                .query(definitionQuery -> definitionQuery.specification(term ->
+                        (root, criteria, criteriaBuilder) -> criteriaBuilder.conjunction()))
+                .query(query);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertEquals("query is already declared", exception.getMessage());
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -397,10 +397,11 @@ class SearchDefinitionTest {
         var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
                 .fields(fields -> fields.add("email", String.class))
                 .query(definitionQuery -> definitionQuery.specification(term ->
-                        (root, criteria, criteriaBuilder) -> criteriaBuilder.conjunction()))
-                .query(query);
+                        (root, criteria, criteriaBuilder) -> criteriaBuilder.conjunction()));
 
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> declareDuplicateQuery(builder, query));
 
         assertEquals("query is already declared", exception.getMessage());
     }
@@ -579,5 +580,11 @@ class SearchDefinitionTest {
         builder.fields(fields -> fields.add("expiresAt", java.time.Instant.class)
                 .subtype(String.class)
                 .filterable(filter -> filter.allow(EQUAL)));
+    }
+
+    private static void declareDuplicateQuery(
+            SearchDefinition.Builder<TestTypes.Product> builder,
+            SearchQuery<TestTypes.Product> query) {
+        builder.query(query);
     }
 }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -566,12 +566,12 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsIgnoreCaseSortingForNonTextPaths() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("amount", BigDecimal.class)
-                                .path("price")
-                                .sortable(SearchSorting.Builder::allowIgnoreCase))
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("amount", BigDecimal.class)
+                        .path("price")
+                        .sortable(SearchSorting.Builder::allowIgnoreCase));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertTrue(exception.getMessage().contains("ignoreCase sorting requires a CharSequence path"));
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -554,12 +554,12 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsSortingThroughCollectionValuedPath() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("reviewRating", Integer.class)
-                                .path("reviews.rating")
-                                .sortable())
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("reviewRating", Integer.class)
+                        .path("reviews.rating")
+                        .sortable());
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertTrue(exception.getMessage().contains("must not traverse collection-valued paths"));
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -224,6 +224,87 @@ class SearchDefinitionTest {
     }
 
     @Test
+    void fallsBackToGlobalPolicyWhenNoDefinitionLimitsAreDeclared() {
+        SearchPolicy global = SearchPolicy.builder()
+                .paging(paging -> paging.maxSize(17))
+                .build();
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class))
+                .build();
+
+        assertSame(global, definition.effectiveLimits(global));
+        assertTrue(definition.limits().isEmpty());
+        assertTrue(SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .limits(global)
+                .fields(fields -> fields.add("email", String.class))
+                .build()
+                .limits()
+                .isPresent());
+    }
+
+    @Test
+    void rejectsDuplicatePagingAndLimitsDeclarations() {
+        var pagingBuilder = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .paging();
+        var explicitLimitsBuilder = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .limits(SearchPolicy.defaults());
+        var customLimitsBuilder = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .limits(limits -> limits.paging(paging -> paging.maxSize(10)));
+
+        assertThrows(IllegalArgumentException.class, pagingBuilder::paging);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> explicitLimitsBuilder.limits(limits -> limits.paging(paging -> paging.maxSize(10))));
+        assertThrows(IllegalArgumentException.class, () -> customLimitsBuilder.limits(SearchPolicy.defaults()));
+    }
+
+    @Test
+    void rejectsDuplicateFilteringAndSortingDeclarations() {
+        assertThrows(IllegalArgumentException.class, () ->
+                SearchDefinition.builder()
+                        .entity(TestTypes.Product.class)
+                        .fields(fields -> fields.add("email", String.class)
+                                .filterable()
+                                .filterable()));
+        assertThrows(IllegalArgumentException.class, () ->
+                SearchDefinition.builder()
+                        .entity(TestTypes.Product.class)
+                        .fields(fields -> fields.add("email", String.class)
+                                .sortable()
+                                .sortable()));
+    }
+
+    @Test
+    void fieldsCustomizerOverloadReturnsTheSameDslAfterApplyingCustomizer() {
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder()
+                .entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class, SearchField.Builder::filterable)
+                        .add("price", BigDecimal.class))
+                .build();
+
+        assertTrue(definition.field("email").orElseThrow().filtering().enabled());
+        assertEquals(BigDecimal.class, definition.field("price").orElseThrow().type());
+    }
+
+    @Test
+    void rejectsDuplicateSelectors() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                SearchDefinition.builder()
+                        .entity(TestTypes.Product.class)
+                        .fields(fields -> {
+                            fields.add("email", String.class);
+                            fields.add("email", String.class);
+                        }));
+
+        assertEquals("selector 'email' is already declared", exception.getMessage());
+    }
+
+    @Test
     void leavesFieldWithoutSortingAsNotSortable() {
         SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder().entity(TestTypes.Product.class)
                 .fields(fields -> fields.add("email", String.class))
@@ -557,6 +638,18 @@ class SearchDefinitionTest {
         var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
                 .fields(fields -> fields.add("reviewRating", Integer.class)
                         .path("reviews.rating")
+                        .sortable());
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
+
+        assertTrue(exception.getMessage().contains("must not traverse collection-valued paths"));
+    }
+
+    @Test
+    void rejectsSortingOnTerminalCollectionValuedPath() {
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("tags", java.util.List.class)
+                        .path("tags")
                         .sortable());
 
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -480,12 +480,12 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsFieldTypeThatDoesNotMatchEntityPath() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("amount", String.class)
-                                .path("price")
-                                .filterable(filter -> filter.allow(EQUAL)))
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("amount", String.class)
+                        .path("price")
+                        .filterable(filter -> filter.allow(EQUAL)));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertEquals(
                 "selector 'amount' path 'price' resolves to type 'java.math.BigDecimal' but was declared as 'java.lang.String'",

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -71,12 +71,12 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsSubtypeOutsideEntityHierarchy() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("expiresAt", java.time.Instant.class)
-                                .subtype(String.class)
-                                .filterable(filter -> filter.allow(EQUAL)))
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("expiresAt", java.time.Instant.class)
+                        .subtype(String.class)
+                        .filterable(filter -> filter.allow(EQUAL)));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertTrue(exception.getMessage().contains("must extend entity"));
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -494,12 +494,12 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsFilteringWithoutAllowedOperators() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("taxId", String.class)
-                                .path("person.taxIdentifier")
-                                .filterable(filter -> {}))
-                        .build());
+        var builder = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("taxId", String.class)
+                        .path("person.taxIdentifier")
+                        .filterable(filter -> {}));
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, builder::build);
 
         assertEquals("selector 'taxId' filtering must declare at least one allowed operator", exception.getMessage());
     }

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -7,6 +7,7 @@ import io.github.ggomarighetti.searchhelper.integration.bench.domain.Product;
 import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
 import io.github.ggomarighetti.searchhelper.query.SearchQuery;
 import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators;
+import io.github.ggomarighetti.searchhelper.sort.SearchSorting;
 import java.math.BigDecimal;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -568,7 +569,7 @@ class SearchDefinitionTest {
                 SearchDefinition.builder().entity(TestTypes.Product.class)
                         .fields(fields -> fields.add("amount", BigDecimal.class)
                                 .path("price")
-                                .sortable(sort -> sort.allowIgnoreCase()))
+                                .sortable(SearchSorting.Builder::allowIgnoreCase))
                         .build());
 
         assertTrue(exception.getMessage().contains("ignoreCase sorting requires a CharSequence path"));

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchDefinitionTest.java
@@ -464,7 +464,7 @@ class SearchDefinitionTest {
         Set<?> operators = definition.filteringOperators();
 
         assertEquals(Set.of(EQUAL, IN), operators);
-        assertThrows(UnsupportedOperationException.class, () -> definition.filteringOperators().clear());
+        assertThrows(UnsupportedOperationException.class, operators::clear);
     }
 
     @Test

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchFilteringTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchFilteringTest.java
@@ -1,0 +1,163 @@
+package io.github.ggomarighetti.searchhelper.unit;
+
+import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidationException;
+import io.github.ggomarighetti.searchhelper.filter.FilterValidationResult;
+import io.github.ggomarighetti.searchhelper.filter.SearchFiltering;
+import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
+import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.EQUAL;
+import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.IN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SearchFilteringTest {
+    @Test
+    void acceptsAllowedOperatorsAndRejectsMissingOperators() {
+        SearchFiltering<String> filtering = SearchFiltering.<String>builder()
+                .allow(EQUAL)
+                .build(
+                        TestTypes.Product.class,
+                        "email",
+                        String.class,
+                        "email",
+                        SearchPolicy.defaults().paths());
+
+        assertTrue(filtering.accepts(EQUAL, List.of("person@example.com"), ApplicationConversionService.getSharedInstance()));
+        assertFalse(filtering.accepts(IN, List.of("person@example.com"), ApplicationConversionService.getSharedInstance()));
+        assertThrows(
+                NullPointerException.class,
+                () -> filtering.accepts(null, List.of("person@example.com"), ApplicationConversionService.getSharedInstance()));
+        assertThrows(
+                NullPointerException.class,
+                () -> filtering.accepts(EQUAL, null, ApplicationConversionService.getSharedInstance()));
+        assertThrows(
+                NullPointerException.class,
+                () -> filtering.accepts(EQUAL, List.of("person@example.com"), null));
+    }
+
+    @Test
+    void rejectsDuplicateOperatorDeclarations() {
+        SearchFiltering.Builder<String> implicitType = SearchFiltering.builder();
+        implicitType.allow(EQUAL);
+        SearchFiltering.Builder<String> explicitType = SearchFiltering.builder();
+        explicitType.allow(EQUAL, String.class, operator -> {});
+
+        assertThrows(IllegalArgumentException.class, () -> implicitType.allow(EQUAL));
+        assertThrows(IllegalArgumentException.class, () -> explicitType.allow(EQUAL, String.class, operator -> {}));
+    }
+
+    @Test
+    void reportsUnsupportedDefaultOperatorProfile() {
+        SearchDefinitionValidationException exception = assertThrows(
+                SearchDefinitionValidationException.class,
+                () -> SearchFiltering.<TestTypes.Person>builder()
+                        .withDefaults()
+                        .build(
+                                TestTypes.Product.class,
+                                "person",
+                                TestTypes.Person.class,
+                                "person",
+                                SearchPolicy.defaults().paths()));
+
+        assertEquals(SearchDefinitionValidationException.DEFAULT_OPERATORS_UNSUPPORTED_TYPE, exception.code());
+    }
+
+    @Test
+    void canDenyOperatorsInheritedFromDefaults() {
+        SearchFiltering<String> filtering = SearchFiltering.<String>builder()
+                .withDefaults()
+                .deny(EQUAL)
+                .build(
+                        TestTypes.Product.class,
+                        "email",
+                        String.class,
+                        "email",
+                        SearchPolicy.defaults().paths());
+
+        assertFalse(filtering.allows(EQUAL));
+        assertTrue(filtering.allows(IN));
+    }
+
+    @Test
+    void validatesExplicitArgumentConversionFailures() {
+        SearchFiltering<String> filtering = SearchFiltering.<String>builder()
+                .allow(EQUAL, NoConversion.class, operator -> {})
+                .build(
+                        TestTypes.Product.class,
+                        "email",
+                        String.class,
+                        "email",
+                        SearchPolicy.defaults().paths());
+
+        FilterValidationResult result = filtering.operators()
+                .get(EQUAL)
+                .validate(List.of("value"), ApplicationConversionService.getSharedInstance());
+
+        assertFalse(result.accepted());
+        assertEquals(NoConversion.class.getName(), result.errors().get(0).optionalTargetType().orElseThrow());
+    }
+
+    @Test
+    void treatsIllegalArgumentConversionAsInputConversionFailure() {
+        SearchFiltering<String> filtering = SearchFiltering.<String>builder()
+                .allow(EQUAL, NoConversion.class, operator -> {})
+                .build(
+                        TestTypes.Product.class,
+                        "email",
+                        String.class,
+                        "email",
+                        SearchPolicy.defaults().paths());
+
+        FilterValidationResult result = filtering.operators()
+                .get(EQUAL)
+                .validate(List.of("value"), new ThrowingConversionService());
+
+        assertFalse(result.accepted());
+        assertEquals(NoConversion.class.getName(), result.errors().get(0).optionalTargetType().orElseThrow());
+    }
+
+    @Test
+    void terminalCollectionFilteringRequiresDistinct() {
+        SearchFiltering<List> filtering = SearchFiltering.<List>builder()
+                .allow(EQUAL)
+                .build(
+                        TestTypes.Product.class,
+                        "tags",
+                        List.class,
+                        "tags",
+                        SearchPolicy.defaults().paths());
+
+        assertTrue(filtering.requiresDistinct());
+    }
+
+    private static final class NoConversion {
+    }
+
+    private static final class ThrowingConversionService implements ConversionService {
+        @Override
+        public boolean canConvert(Class<?> sourceType, Class<?> targetType) {
+            return true;
+        }
+
+        @Override
+        public boolean canConvert(TypeDescriptor sourceType, TypeDescriptor targetType) {
+            return true;
+        }
+
+        @Override
+        public <T> T convert(Object source, Class<T> targetType) {
+            throw new IllegalArgumentException("bad input");
+        }
+
+        @Override
+        public Object convert(Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+            throw new IllegalArgumentException("bad input");
+        }
+    }
+}

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchPathTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchPathTest.java
@@ -1,0 +1,310 @@
+package io.github.ggomarighetti.searchhelper.unit;
+
+import io.github.ggomarighetti.searchhelper.definition.SearchPath;
+import io.github.ggomarighetti.searchhelper.exception.SearchDefinitionValidationException;
+import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SearchPathTest {
+    private static final SearchPolicy.Paths DEEP_PATHS = new SearchPolicy.Paths(6);
+
+    @Test
+    void validateUsesDefaultPathLimits() {
+        SearchPath.validate(TestTypes.Product.class, "amount", "price", BigDecimal.class);
+    }
+
+    @Test
+    void resolvesDirectFieldsSetterOnlyPropertiesAndInheritedFields() {
+        SearchPath.Metadata fieldOnly = SearchPath.metadata(
+                FieldOnlyRoot.class,
+                "code",
+                "code",
+                String.class,
+                DEEP_PATHS);
+        SearchPath.Metadata setterOnly = SearchPath.metadata(
+                SetterOnlyRoot.class,
+                "label",
+                "writeOnly.label",
+                String.class,
+                DEEP_PATHS);
+        SearchPath.Metadata inherited = SearchPath.metadata(
+                ChildFieldRoot.class,
+                "inherited",
+                "inherited",
+                String.class,
+                DEEP_PATHS);
+
+        assertEquals(String.class, fieldOnly.type());
+        assertEquals(String.class, setterOnly.type());
+        assertEquals(String.class, inherited.type());
+    }
+
+    @Test
+    void resolvesCollectionElementTypesFromArraysMapsAndIterableHierarchy() {
+        assertCollectionPath("arrayLines.sku");
+        assertCollectionPath("linesBySku.sku");
+        assertCollectionPath("lineBag.sku");
+        assertCollectionPath("lineIterable.sku");
+        assertCollectionPath("wildcardLines.sku");
+    }
+
+    @Test
+    void reportsTerminalCollectionMetadataWithoutTraversingThroughIt() {
+        SearchPath.Metadata array = SearchPath.metadata(
+                CollectionRoot.class,
+                "arrayLines",
+                "arrayLines",
+                Line[].class,
+                DEEP_PATHS);
+        SearchPath.Metadata map = SearchPath.metadata(
+                CollectionRoot.class,
+                "linesBySku",
+                "linesBySku",
+                Map.class,
+                DEEP_PATHS);
+
+        assertEquals(Line[].class, array.type());
+        assertFalse(array.traversesCollection());
+        assertTrue(array.collectionValued());
+        assertEquals(Map.class, map.type());
+        assertFalse(map.traversesCollection());
+        assertTrue(map.collectionValued());
+    }
+
+    @Test
+    void rejectsCollectionPathsWhenElementTypeCannotResolveToAPropertyOwner() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPath.metadata(GenericRoot.class, "sku", "genericLines.sku", String.class, DEEP_PATHS));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPath.metadata(GenericRoot.class, "sku", "nestedLines.sku", String.class, DEEP_PATHS));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPath.metadata(GenericRoot.class, "sku", "arrayLines.sku", String.class, DEEP_PATHS));
+    }
+
+    @Test
+    void rejectsBlankMissingAndTooDeepSegments() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPath.metadata(TestTypes.Product.class, "name", "customer..name", String.class, DEEP_PATHS));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPath.metadata(TestTypes.Product.class, "missing", "missing", String.class, DEEP_PATHS));
+
+        SearchDefinitionValidationException exception = assertThrows(
+                SearchDefinitionValidationException.class,
+                () -> SearchPath.metadata(
+                        TestTypes.Product.class,
+                        "countryCode",
+                        "customer.region.country.code",
+                        String.class,
+                        new SearchPolicy.Paths(3)));
+
+        assertEquals(SearchDefinitionValidationException.PATH_LIMIT_EXCEEDED, exception.code());
+    }
+
+    @Test
+    void derivesTopologyFromJpaAnnotationsAndEntityTargets() {
+        assertTopology("buyer.sku", Set.of("buyer"), Set.of());
+        assertTopology("invoice.number", Set.of("invoice"), Set.of());
+        assertTopology("entityTarget.name", Set.of("entityTarget"), Set.of());
+        assertTopology("orders.number", Set.of("orders"), Set.of("orders"));
+        assertTopology("tags.label", Set.of("tags"), Set.of("tags"));
+
+        SearchPath.Topology labels = SearchPath.topology(TopologyRoot.class, "labels", "labels", DEEP_PATHS);
+        assertEquals(Set.of("labels"), labels.joinedPaths());
+        assertEquals(Set.of("labels"), labels.toManyPaths());
+    }
+
+    @Test
+    void topologyDefensivelyCopiesSetsAndExposesEmptyTopology() {
+        Set<String> joinedPaths = new java.util.LinkedHashSet<>();
+        joinedPaths.add("buyer");
+        Set<String> toManyPaths = new java.util.LinkedHashSet<>();
+        toManyPaths.add("orders");
+
+        SearchPath.Topology topology = new SearchPath.Topology(2, joinedPaths, toManyPaths);
+        joinedPaths.clear();
+        toManyPaths.clear();
+
+        assertEquals(Set.of("buyer"), topology.joinedPaths());
+        assertEquals(Set.of("orders"), topology.toManyPaths());
+        assertThrows(UnsupportedOperationException.class, () -> topology.joinedPaths().add("other"));
+        assertEquals(new SearchPath.Topology(0, Set.of(), Set.of()), SearchPath.Topology.none());
+    }
+
+    private static void assertCollectionPath(String path) {
+        SearchPath.Metadata metadata = SearchPath.metadata(CollectionRoot.class, "sku", path, String.class, DEEP_PATHS);
+
+        assertEquals(String.class, metadata.type());
+        assertTrue(metadata.traversesCollection());
+        assertFalse(metadata.collectionValued());
+    }
+
+    private static void assertTopology(String path, Set<String> joinedPaths, Set<String> toManyPaths) {
+        SearchPath.Topology topology = SearchPath.topology(TopologyRoot.class, path, path, DEEP_PATHS);
+
+        assertEquals(joinedPaths, topology.joinedPaths());
+        assertEquals(toManyPaths, topology.toManyPaths());
+    }
+
+    private static final class FieldOnlyRoot {
+        private String code;
+    }
+
+    private static class BaseFieldRoot {
+        private String inherited;
+    }
+
+    private static final class ChildFieldRoot extends BaseFieldRoot {
+    }
+
+    private static final class SetterOnlyRoot {
+        @SuppressWarnings("unused")
+        private WriteOnly writeOnly;
+
+        public void setWriteOnly(WriteOnly writeOnly) {
+            this.writeOnly = writeOnly;
+        }
+    }
+
+    private static final class WriteOnly {
+        public String getLabel() {
+            return null;
+        }
+    }
+
+    private static final class CollectionRoot {
+        public Line[] getArrayLines() {
+            return new Line[0];
+        }
+
+        public Map<String, Line> getLinesBySku() {
+            return Map.of();
+        }
+
+        public LineBag getLineBag() {
+            return new LineBag();
+        }
+
+        public LineIterable getLineIterable() {
+            return new LineIterable();
+        }
+
+        public List<? extends Line> getWildcardLines() {
+            return List.of();
+        }
+    }
+
+    private static final class GenericRoot<T extends Line> {
+        public List<T> getGenericLines() {
+            return List.of();
+        }
+
+        public List<List<Line>> getNestedLines() {
+            return List.of();
+        }
+
+        public List<T[]> getArrayLines() {
+            return List.of();
+        }
+    }
+
+    private static final class Line {
+        public String getSku() {
+            return null;
+        }
+    }
+
+    private static final class LineBag extends ArrayList<Line> {
+    }
+
+    private static final class LineIterable implements Iterable<Line> {
+        @Override
+        public Iterator<Line> iterator() {
+            return List.<Line>of().iterator();
+        }
+    }
+
+    @Entity
+    private static final class EntityTarget {
+        public String getName() {
+            return null;
+        }
+    }
+
+    private static final class Invoice {
+        public String getNumber() {
+            return null;
+        }
+    }
+
+    private static final class Order {
+        public String getNumber() {
+            return null;
+        }
+    }
+
+    private static final class Tag {
+        public String getLabel() {
+            return null;
+        }
+    }
+
+    private static final class TopologyRoot {
+        @ManyToOne
+        private Line buyer;
+
+        @OneToMany
+        private List<Order> orders;
+
+        @ManyToMany
+        private Set<Tag> tags;
+
+        @ElementCollection
+        private List<String> labels;
+
+        public Line getBuyer() {
+            return buyer;
+        }
+
+        @OneToOne
+        public Invoice getInvoice() {
+            return null;
+        }
+
+        public EntityTarget getEntityTarget() {
+            return null;
+        }
+
+        public List<Order> getOrders() {
+            return orders;
+        }
+
+        public Set<Tag> getTags() {
+            return tags;
+        }
+
+        public List<String> getLabels() {
+            return labels;
+        }
+    }
+}

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchPolicyTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SearchPolicyTest.java
@@ -1,0 +1,48 @@
+package io.github.ggomarighetti.searchhelper.unit;
+
+import io.github.ggomarighetti.searchhelper.policy.SearchPolicy;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SearchPolicyTest {
+    @Test
+    void nestedBuildersCreateDefaultPolicyGroups() {
+        SearchPolicy defaults = SearchPolicy.defaults();
+
+        assertEquals(defaults.rsql(), SearchPolicy.Rsql.builder().build());
+        assertEquals(defaults.filter(), SearchPolicy.Filter.builder().build());
+        assertEquals(defaults.filter().like(), SearchPolicy.Filter.Like.builder().build());
+        assertEquals(defaults.paging(), SearchPolicy.Paging.builder().build());
+        assertEquals(defaults.paging().page(), SearchPolicy.Paging.Page.builder().build());
+        assertEquals(defaults.paging().slice(), SearchPolicy.Paging.Slice.builder().build());
+        assertEquals(defaults.sorting(), SearchPolicy.Sorting.builder().build());
+        assertEquals(defaults.query(), SearchPolicy.Query.builder().build());
+        assertEquals(defaults.paths(), SearchPolicy.Paths.builder().build());
+    }
+
+    @Test
+    void rejectsInvalidNumericLimits() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPolicy.Rsql.builder().maxLength(0).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPolicy.Sorting.builder().maxRelationOrders(-1).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPolicy.Paging.builder().maxOffset(-1).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPolicy.Paging.builder().minPage(2).maxPage(1).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPolicy.Paging.builder().minSize(20).maxSize(10).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPolicy.Paging.builder().unpagedSize(20).maxUnpagedSize(10).build());
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPolicy.Query.builder().minLength(5).maxLength(4).build());
+    }
+}

--- a/src/test/java/io/github/ggomarighetti/searchhelper/unit/SmallApiCoverageTest.java
+++ b/src/test/java/io/github/ggomarighetti/searchhelper/unit/SmallApiCoverageTest.java
@@ -1,0 +1,227 @@
+package io.github.ggomarighetti.searchhelper.unit;
+
+import io.github.ggomarighetti.searchhelper.exception.RsqlValidationError;
+import io.github.ggomarighetti.searchhelper.filter.FilterValidationError;
+import io.github.ggomarighetti.searchhelper.page.SearchPaging;
+import io.github.ggomarighetti.searchhelper.query.SearchQuery;
+import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperator;
+import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorArity;
+import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorDescriptor;
+import io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperatorRegistry;
+import io.github.ggomarighetti.searchhelper.sort.SearchSorting;
+import io.github.ggomarighetti.searchhelper.validation.RuleViolation;
+import java.util.List;
+import java.util.Set;
+import org.hibernate.validator.cfg.defs.MinDef;
+import org.hibernate.validator.cfg.defs.SizeDef;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+import static io.github.ggomarighetti.searchhelper.rsql.operator.RsqlOperators.EQUAL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.data.domain.Sort.Direction.ASC;
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+class SmallApiCoverageTest {
+    @Test
+    void disabledPagingRejectsValuesAndReturnsNoViolations() {
+        SearchPaging paging = SearchPaging.disabled();
+
+        assertFalse(paging.accepts(0, 10));
+        assertFalse(paging.acceptsPage(0));
+        assertFalse(paging.acceptsSize(10));
+        assertEquals(List.of(), paging.pageViolations(-1));
+        assertEquals(List.of(), paging.sizeViolations(100));
+    }
+
+    @Test
+    void pagingAppliesPageAndSizeRulesIndependently() {
+        SearchPaging paging = SearchPaging.builder()
+                .page(page -> page.rule(new MinDef().value(1)))
+                .size(size -> size.rule(new MinDef().value(2)))
+                .build();
+
+        assertTrue(paging.accepts(1, 2));
+        assertTrue(paging.acceptsPage(1));
+        assertTrue(paging.acceptsSize(2));
+        assertFalse(paging.accepts(0, 2));
+        assertFalse(paging.accepts(1, 1));
+        assertFalse(paging.acceptsPage(0));
+        assertFalse(paging.acceptsSize(1));
+        assertEquals(1, paging.pageViolations(0).size());
+        assertEquals(1, paging.sizeViolations(1).size());
+        assertThrows(NullPointerException.class, () -> SearchPaging.builder().page(null));
+        assertThrows(NullPointerException.class, () -> SearchPaging.builder().size(null));
+        assertThrows(NullPointerException.class, () -> new SearchPaging.Rules<Integer>().rule(null));
+    }
+
+    @Test
+    void disabledQueryRejectsTextAndCannotBuildSpecification() {
+        SearchQuery<TestTypes.Product> query = SearchQuery.disabled();
+
+        assertFalse(query.accepts("needle"));
+        assertFalse(query.hasRules());
+        assertEquals(List.of(), query.violations("needle"));
+        assertThrows(IllegalStateException.class, () -> query.toSpecification("needle"));
+    }
+
+    @Test
+    void queryBuilderValidatesRequiredAndDuplicateSpecification() {
+        SearchQuery.Builder<TestTypes.Product> builder = SearchQuery.builder();
+        builder.specification(term -> (root, criteria, criteriaBuilder) -> criteriaBuilder.conjunction());
+
+        assertThrows(IllegalArgumentException.class, () -> SearchQuery.builder().build());
+        assertThrows(NullPointerException.class, () -> SearchQuery.builder().rule(null));
+        assertThrows(NullPointerException.class, () -> SearchQuery.builder().specification(null));
+        assertThrows(IllegalArgumentException.class, () -> builder.specification(term ->
+                (root, criteria, criteriaBuilder) -> criteriaBuilder.conjunction()));
+    }
+
+    @Test
+    void queryWithRulesReportsViolationsAndDelegatesSpecificationFactory() {
+        var specification = (org.springframework.data.jpa.domain.Specification<TestTypes.Product>)
+                (root, criteria, criteriaBuilder) -> criteriaBuilder.conjunction();
+        SearchQuery<TestTypes.Product> query = SearchQuery.<TestTypes.Product>builder()
+                .rule(new SizeDef().min(3))
+                .specification(term -> specification)
+                .build();
+
+        assertTrue(query.enabled());
+        assertTrue(query.hasRules());
+        assertTrue(query.accepts("abcd"));
+        assertFalse(query.accepts("ab"));
+        assertEquals(1, query.violations("ab").size());
+        assertSame(specification, query.toSpecification("abcd"));
+    }
+
+    @Test
+    void disabledAndCustomizedSortingExposeAcceptanceRules() {
+        SearchSorting disabled = SearchSorting.disabled();
+        SearchSorting sorting = SearchSorting.builder()
+                .allow(ASC)
+                .allowIgnoreCase()
+                .allowNullHandling(Sort.NullHandling.NULLS_FIRST)
+                .build(TestTypes.Product.class, "email", String.class, "email", io.github.ggomarighetti.searchhelper.policy.SearchPolicy.defaults().paths());
+
+        assertFalse(disabled.accepts(ASC));
+        assertFalse(disabled.acceptsIgnoreCase(false));
+        assertFalse(disabled.acceptsNullHandling(Sort.NullHandling.NATIVE));
+        assertThrows(NullPointerException.class, () -> disabled.accepts(null));
+        assertThrows(NullPointerException.class, () -> disabled.acceptsNullHandling(null));
+        assertTrue(sorting.accepts(ASC));
+        assertFalse(sorting.accepts(DESC));
+        assertTrue(sorting.ignoreCase());
+        assertTrue(sorting.nullHandling().contains(Sort.NullHandling.NULLS_FIRST));
+        assertTrue(sorting.acceptsIgnoreCase(true));
+        assertTrue(sorting.acceptsIgnoreCase(false));
+        assertTrue(sorting.acceptsNullHandling(Sort.NullHandling.NULLS_FIRST));
+        assertFalse(sorting.acceptsNullHandling(Sort.NullHandling.NULLS_LAST));
+        assertThrows(IllegalArgumentException.class, () -> SearchSorting.builder().allow());
+        assertThrows(NullPointerException.class, () -> SearchSorting.builder().allow((org.springframework.data.domain.Sort.Direction) null));
+        assertThrows(IllegalArgumentException.class, () -> SearchSorting.builder().allowNullHandling());
+        assertThrows(NullPointerException.class, () -> SearchSorting.builder().allowNullHandling((Sort.NullHandling) null));
+    }
+
+    @Test
+    void filterValidationErrorsExposeOptionalDetailsAndRejectInvalidShapes() {
+        RuleViolation violation = new RuleViolation("value", "bad", "{bad}", "Constraint");
+        FilterValidationError conversion = FilterValidationError.conversionFailed(0, Integer.class);
+        FilterValidationError argument = FilterValidationError.argumentRule(1, violation);
+        FilterValidationError arguments = FilterValidationError.argumentsRule(violation);
+
+        assertEquals(0, conversion.optionalArgumentIndex().orElseThrow());
+        assertEquals(Integer.class.getName(), conversion.optionalTargetType().orElseThrow());
+        assertTrue(conversion.optionalViolation().isEmpty());
+        assertEquals(1, argument.optionalArgumentIndex().orElseThrow());
+        assertEquals(violation, argument.optionalViolation().orElseThrow());
+        assertTrue(arguments.optionalArgumentIndex().isEmpty());
+        assertThrows(IllegalArgumentException.class, () ->
+                new FilterValidationError(FilterValidationError.Code.ARGUMENT_RULE, -1, null, violation));
+        assertThrows(NullPointerException.class, () -> FilterValidationError.conversionFailed(0, null));
+        assertThrows(NullPointerException.class, () ->
+                new FilterValidationError(FilterValidationError.Code.CONVERSION_FAILED, null, null, null));
+        assertThrows(NullPointerException.class, () ->
+                new FilterValidationError(FilterValidationError.Code.ARGUMENTS_RULE, null, null, null));
+    }
+
+    @Test
+    void ruleViolationCanReplaceOrPrefixPaths() {
+        RuleViolation blank = new RuleViolation("", "message", "{message}", "Constraint");
+        RuleViolation nested = new RuleViolation("name", "message", "{message}", "Constraint");
+
+        assertEquals("field", blank.prefixed("field").path());
+        assertEquals("field.name", nested.prefixed("field").path());
+        assertEquals("other", nested.withPath("other").path());
+        assertThrows(NullPointerException.class, () -> nested.prefixed(null));
+        assertThrows(NullPointerException.class, () -> new RuleViolation(null, "message", "{message}", "Constraint"));
+    }
+
+    @Test
+    void rsqlValidationErrorRejectsInvalidLocationAndArgumentIndex() {
+        RsqlValidationError error = new RsqlValidationError(
+                RsqlValidationError.FIELD_NOT_ALLOWED,
+                "$",
+                "email",
+                EQUAL.name(),
+                null,
+                null,
+                "message",
+                null,
+                null);
+
+        assertEquals("email", error.selector());
+        assertThrows(IllegalArgumentException.class, () ->
+                new RsqlValidationError(" ", "$", null, null, null, null, "message", null, null));
+        assertThrows(IllegalArgumentException.class, () ->
+                new RsqlValidationError(RsqlValidationError.FIELD_NOT_ALLOWED, " ", null, null, null, null, "message", null, null));
+        assertThrows(IllegalArgumentException.class, () ->
+                new RsqlValidationError(RsqlValidationError.FIELD_NOT_ALLOWED, "$", null, null, -1, null, "message", null, null));
+    }
+
+    @Test
+    void rsqlOperatorArityValidatesRangesAndAcceptance() {
+        RsqlOperatorArity exact = RsqlOperatorArity.exact(2);
+        RsqlOperatorArity bounded = RsqlOperatorArity.between(1, 3);
+        RsqlOperatorArity unbounded = RsqlOperatorArity.atLeast(1);
+
+        assertTrue(exact.accepts(2));
+        assertFalse(exact.accepts(1));
+        assertFalse(bounded.accepts(0));
+        assertTrue(bounded.accepts(3));
+        assertTrue(unbounded.accepts(100));
+        assertThrows(IllegalArgumentException.class, () -> RsqlOperatorArity.exact(-1));
+        assertThrows(IllegalArgumentException.class, () -> RsqlOperatorArity.between(2, 1));
+    }
+
+    @Test
+    void rsqlOperatorDescriptorsAndRegistryValidateSymbols() {
+        RsqlOperator custom = RsqlOperator.of("custom");
+        RsqlOperator other = RsqlOperator.of("other");
+        RsqlOperatorDescriptor descriptor = RsqlOperatorDescriptor.builder(custom)
+                .symbols("=custom=", "=c=")
+                .exactArguments(2)
+                .argumentType(String.class)
+                .jpaPredicate(context -> null)
+                .build();
+        RsqlOperatorRegistry registry = new RsqlOperatorRegistry(List.of(descriptor));
+
+        assertEquals(custom, descriptor.operator());
+        assertEquals("=custom=", descriptor.symbol());
+        assertEquals(Set.of("=custom=", "=c="), descriptor.symbols());
+        assertEquals(String.class, descriptor.argumentType().orElseThrow());
+        assertTrue(descriptor.jpaPredicateFactory().isPresent());
+        assertFalse(descriptor.defaultJpaSupported());
+        assertEquals(descriptor, registry.require(custom));
+        assertTrue(registry.descriptor(descriptor.comparisonOperator()).isPresent());
+        assertTrue(registry.descriptor(other).isEmpty());
+        assertThrows(IllegalArgumentException.class, () -> registry.require(other));
+        assertThrows(IllegalArgumentException.class, () -> RsqlOperatorDescriptor.builder(custom).build());
+        assertThrows(IllegalArgumentException.class, () -> new RsqlOperatorRegistry(List.of(descriptor, descriptor)));
+        assertThrows(IllegalArgumentException.class, () -> new RsqlOperatorRegistry(List.of(
+                descriptor,
+                RsqlOperatorDescriptor.of(other, "=custom="))));
+    }
+}


### PR DESCRIPTION
### Resume
- Adds focused unit coverage across search properties, path resolution, filtering, policy builders, RSQL validation, JPA definition validation, and protection guards.
- Raises clean JaCoCo line coverage to 99.31% while keeping all existing integration coverage green.
- Hardens the verification workflow by pinning the Codecov action to a full commit SHA.
- Refactors RSQL exception assertions so each `assertThrows` lambda targets a single runtime invocation.

### Evidence
- Ran `.\mvnw.cmd clean -Pcoverage verify`.

### Reference
> Not required