### PR TITLE
ci(release): disable Release Please snapshot PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "skip-github-release": true,
+      "skip-snapshot": true,
       "pull-request-title-pattern": "chore${scope}: release ${component} ${version}",
       "changelog-sections": [
         {


### PR DESCRIPTION
## Summary
- disable Release Please Maven snapshot PRs with `skip-snapshot: true`
- keep release PRs focused on real final versions instead of post-release `*-SNAPSHOT` bumps

## Verification
- parsed `release-please-config.json` locally with PowerShell JSON parsing
- confirmed autogenerated snapshot PR #22 was closed and its remote branch deleted