### PR TITLE
feat: harden search validation and rsql extensibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,9 @@ fields.add("birthDate", LocalDate.class)
 ```
 
 Definition paths are checked against Java properties while the DSL is built and,
-in JPA applications, against the JPA metamodel when first compiled.
+in JPA applications, against the JPA metamodel when first compiled. Collection
+element types can be resolved from concrete generic supertypes and bounded type
+variables, such as `List<T extends Line>`.
 
 ### Filtering
 

--- a/README.md
+++ b/README.md
@@ -527,6 +527,13 @@ of 100 with a 5000-row offset cap, unpaged requests are disabled, sort orders
 are capped at 3, to-many sorting is rejected, slice compilation is enabled, and
 definition paths are capped at 3 segments.
 
+When unpaged requests are enabled with `jpa.rsql.search.paging.allow-unpaged`
+or a per-definition limit override, the compiler still does not return an
+unbounded `Pageable`. It records the original unpaged input for protection
+checks, translates allowed sort aliases, and returns `PageRequest.of(0,
+defaultUnpagedSize, translatedSort)`. Use
+`jpa.rsql.search.paging.default-unpaged-size` to choose that bounded page size.
+
 Setting `jpa.rsql.search.rsql.enabled=false` disables the built-in RSQL engine,
 Perplexhub backend, and related RSQL infrastructure. In that mode the
 auto-configuration still creates `SearchDefinitionFactory`, but it creates

--- a/README.md
+++ b/README.md
@@ -572,6 +572,13 @@ argument index, validation path, message, message template, and constraint.
 it includes path, message, template, and constraint type, but intentionally omits
 the invalid value.
 
+Protection limits are intentionally allowed to win over some semantic RSQL
+errors. After an operator is registered and a selector is declared, the compiler
+records comparison limits before selector-specific operator checks and argument
+conversion/validation. For oversized or adversarial input, callers may therefore
+receive `SearchProtectionException` instead of a more specific
+`RsqlValidationError` such as operator-not-allowed or argument-rule-violation.
+
 That makes custom rules declared with `SizeDef`, `PatternDef`, `MaxDef`, and
 other Hibernate Validator definitions behave like normal DTO validation from an
 API boundary perspective: you can transmit structured validation details to the

--- a/README.md
+++ b/README.md
@@ -202,6 +202,13 @@ SearchDefinition<Product> definition = searchDefinitionFactory.builder()
         .build();
 ```
 
+Definitions are designed to be reused. Prefer static fields, singleton beans, or
+other long-lived holders instead of rebuilding the same definition for every
+request. Definitions that are built dynamically and then discarded implement
+`AutoCloseable`; call `close()` after the last use to release Hibernate
+Validator factories deterministically. Long-lived definitions can simply stay
+open for the lifetime of the application.
+
 Declare public fields inside `.fields(...)`. A field starts as metadata only;
 filtering and sorting are disabled until enabled explicitly.
 

--- a/README.md
+++ b/README.md
@@ -527,6 +527,12 @@ of 100 with a 5000-row offset cap, unpaged requests are disabled, sort orders
 are capped at 3, to-many sorting is rejected, slice compilation is enabled, and
 definition paths are capped at 3 segments.
 
+Setting `jpa.rsql.search.rsql.enabled=false` disables the built-in RSQL engine,
+Perplexhub backend, and related RSQL infrastructure. In that mode the
+auto-configuration still creates `SearchDefinitionFactory`, but it creates
+`SearchCompiler` only when the application provides its own `SearchRsqlEngine`
+bean.
+
 Per-use case `.limits(...)` overlays remain useful when one endpoint needs a
 tighter profile than the global defaults:
 

--- a/README.md
+++ b/README.md
@@ -647,6 +647,11 @@ The everyday API is intentionally small, but the RSQL layer remains extensible.
 | `ConversionService` / `Converter<String, T>` | Add application-specific value conversion |
 | `jpa.rsql.search.rsql.perplexhub.*` | Configure the bundled Perplexhub backend |
 
+`SearchRsqlEngine.builder()` starts with the built-in operator dialect. For a
+strictly custom dialect, call `.withoutDefaultOperators()` before adding custom
+`RsqlOperatorDescriptor` instances. In Spring Boot, a `SearchRsqlEngineCustomizer`
+can do the same for the auto-configured engine.
+
 ### Perplexhub Backend
 
 The default backend is `PerplexhubRsqlBackendAdapter`. It wraps Perplexhub's

--- a/README.md
+++ b/README.md
@@ -677,6 +677,12 @@ For a custom operator executed by the default backend, always declare:
 - an `argumentType(...)` compatible with `Comparable`;
 - a `jpaPredicate(...)` implementation.
 
+`RsqlOperatorDescriptor.argumentType(...)` accepts any Java type so custom
+backends can use application-specific value objects. The bundled Perplexhub
+backend is stricter because `RSQLCustomPredicate` requires a `Comparable`
+argument type; non-comparable argument types are supported only with a backend
+that can execute them.
+
 The predicate receives an `RsqlJpaPredicateContext` with the
 `CriteriaBuilder`, resolved JPA `Path`, metamodel `Attribute`, converted
 arguments, root/from, and logical operator. The same `ConversionService` is used
@@ -753,7 +759,7 @@ Perplexhub backend, a registered operator that is not built in must have a JPA
 predicate; otherwise the definition fails with
 `RSQL_OPERATOR_NOT_EXECUTABLE`. If `.jpaPredicate(...)` is present,
 `.argumentType(...)` is required so the backend can create the matching
-Perplexhub custom predicate.
+Perplexhub custom predicate, and that type must implement `Comparable`.
 
 ### Custom Conversion
 

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/autoconfigure/JpaRsqlSearchAutoConfiguration.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/autoconfigure/JpaRsqlSearchAutoConfiguration.java
@@ -32,6 +32,7 @@ class JpaRsqlSearchAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnBean(SearchRsqlEngine.class)
     @ConditionalOnMissingBean
     public SearchCompiler searchCompiler(
             SearchRsqlEngine engine,

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/autoconfigure/JpaRsqlSearchProperties.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/autoconfigure/JpaRsqlSearchProperties.java
@@ -482,11 +482,11 @@ class JpaRsqlSearchProperties {
         private int maxSize = SearchPolicy.defaults().paging().maxSize();
         /** Maximum accepted row offset. */
         private long maxOffset = SearchPolicy.defaults().paging().maxOffset();
-        /** Whether unpaged requests are allowed. */
+        /** Whether unpaged requests are accepted and converted to a bounded first page. */
         private boolean allowUnpaged = SearchPolicy.defaults().paging().allowUnpaged();
-        /** Size used to bound an accepted unpaged request. */
+        /** Page size used when an accepted unpaged request is converted to a bounded first page. */
         private int defaultUnpagedSize = SearchPolicy.defaults().paging().defaultUnpagedSize();
-        /** Maximum size accepted for an unpaged request. */
+        /** Maximum configured size accepted for converted unpaged requests. */
         private int maxUnpagedSize = SearchPolicy.defaults().paging().maxUnpagedSize();
 
         public Page getPage() {

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/autoconfigure/JpaRsqlSearchProperties.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/autoconfigure/JpaRsqlSearchProperties.java
@@ -116,7 +116,11 @@ class JpaRsqlSearchProperties {
 
     /** RSQL parser and backend settings. */
     public static class Rsql {
-        /** Whether RSQL support and its auto-configuration are enabled. */
+        /**
+         * Whether the built-in RSQL engine and backend auto-configuration are enabled.
+         * When disabled, a SearchCompiler is auto-configured only if the application
+         * provides its own SearchRsqlEngine bean.
+         */
         private boolean enabled = true;
         /** Settings for the bundled Perplexhub JPA backend. */
         private final Perplexhub perplexhub = new Perplexhub();

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/compile/RsqlRulesValidator.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/compile/RsqlRulesValidator.java
@@ -95,6 +95,8 @@ final class RsqlRulesValidator {
             return;
         }
 
+        // Enforce request protection before selector-specific semantic checks so
+        // declared selectors cannot hide oversized arguments behind invalid input.
         protection.recordComparison(field, descriptor, arguments.size(), arguments);
         if (!isFilteringAllowed(field, comparison, descriptor, path, errors)) {
             return;

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/compile/SearchSpecificationSorting.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/compile/SearchSpecificationSorting.java
@@ -2,6 +2,7 @@ package io.github.ggomarighetti.jparsqlsearch.compile;
 
 import io.github.ggomarighetti.jparsqlsearch.definition.SearchDefinition;
 import io.github.ggomarighetti.jparsqlsearch.definition.SearchField;
+import io.github.ggomarighetti.jparsqlsearch.definition.SearchPath;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.From;
@@ -94,7 +95,7 @@ final class SearchSpecificationSorting {
 
     private static Path<?> path(Path<?> root, String path) {
         Path<?> current = root;
-        for (String segment : path.split("\\.")) {
+        for (String segment : SearchPath.segments(path)) {
             current = current.get(segment);
         }
         return current;

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/definition/SearchDefinition.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/definition/SearchDefinition.java
@@ -21,7 +21,7 @@ import org.springframework.util.Assert;
  *
  * @param <T> entity type compiled by this definition
  */
-public final class SearchDefinition<T> {
+public final class SearchDefinition<T> implements AutoCloseable {
     private static final String CUSTOMIZER_MUST_NOT_BE_NULL = "customizer must not be null";
 
     private final Class<T> entity;
@@ -190,6 +190,20 @@ public final class SearchDefinition<T> {
                 .filter(field -> field.sorting().enabled())
                 .forEach(field -> directions.put(field.selector(), field.sorting().directions()));
         return Collections.unmodifiableMap(directions);
+    }
+
+    /**
+     * Releases validator resources owned by this definition.
+     *
+     * <p>Most applications should keep definitions as long-lived singleton objects.
+     * Call this method only for definitions built dynamically and no longer used.
+     * Closing is idempotent.
+     */
+    @Override
+    public void close() {
+        fields.values().forEach(SearchField::close);
+        paging.close();
+        query.close();
     }
 
     /** First DSL step that requires the root entity type. */

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/definition/SearchField.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/definition/SearchField.java
@@ -13,7 +13,7 @@ import org.springframework.util.Assert;
  *
  * @param <T> exposed value type
  */
-public final class SearchField<T> {
+public final class SearchField<T> implements AutoCloseable {
     private final String selector;
     private final Optional<String> path;
     private final Class<T> type;
@@ -94,6 +94,12 @@ public final class SearchField<T> {
      */
     public SearchSorting sorting() {
         return sorting;
+    }
+
+    /** Releases validator resources owned by this field. */
+    @Override
+    public void close() {
+        filtering.close();
     }
 
     /**

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/definition/SearchPath.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/definition/SearchPath.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -224,7 +225,10 @@ public final class SearchPath {
             Class<?> entity,
             String selector,
             String path) {
-        Class<?> elementType = collectionElementType(resolved.type(), resolved.genericType());
+        Class<?> elementType = collectionElementType(
+                resolved.type(),
+                resolved.genericType(),
+                resolved.typeVariables());
         if (elementType == null) {
             throw unresolved(entity, selector, path);
         }
@@ -240,7 +244,8 @@ public final class SearchPath {
                     readMethod.getReturnType(),
                     readMethod.getGenericReturnType(),
                     readMethod,
-                    field);
+                    field,
+                    typeVariables(owner, readMethod.getDeclaringClass()));
         }
         Class<?> descriptorType = descriptor == null ? null : descriptor.getPropertyType();
         if (descriptorType != null) {
@@ -248,58 +253,95 @@ public final class SearchPath {
                     descriptorType,
                     descriptorType,
                     null,
-                    field);
+                    field,
+                    Map.of());
         }
         return field == null
                 ? null
-                : new ResolvedSegment(field.getType(), field.getGenericType(), field, null);
+                : new ResolvedSegment(
+                        field.getType(),
+                        field.getGenericType(),
+                        field,
+                        null,
+                        typeVariables(owner, field.getDeclaringClass()));
     }
 
     private static Class<?> collectionElementType(Class<?> type, Type genericType) {
+        return collectionElementType(type, genericType, Map.of());
+    }
+
+    private static Class<?> collectionElementType(
+            Class<?> type,
+            Type genericType,
+            Map<TypeVariable<?>, Type> typeVariables) {
         if (type.isArray()) {
             return type.getComponentType();
         }
         if (genericType instanceof GenericArrayType genericArrayType) {
-            return classFromType(genericArrayType.getGenericComponentType());
+            return classFromType(genericArrayType.getGenericComponentType(), typeVariables);
         }
         if (Map.class.isAssignableFrom(type)) {
-            return genericArgument(genericType, Map.class, 1);
+            return genericArgument(genericType, Map.class, 1, typeVariables);
         }
         if (Iterable.class.isAssignableFrom(type)) {
-            return genericArgument(genericType, Iterable.class, 0);
+            return genericArgument(genericType, Iterable.class, 0, typeVariables);
         }
         return null;
     }
 
     private static Class<?> genericArgument(Type type, Class<?> target, int index) {
+        return genericArgument(type, target, index, Map.of());
+    }
+
+    private static Class<?> genericArgument(
+            Type type,
+            Class<?> target,
+            int index,
+            Map<TypeVariable<?>, Type> typeVariables) {
         if (type instanceof ParameterizedType parameterizedType) {
             Class<?> rawClass = rawClass(parameterizedType.getRawType());
             Type[] arguments = parameterizedType.getActualTypeArguments();
             if (rawClass != null && target.isAssignableFrom(rawClass) && arguments.length > index) {
-                return classFromType(arguments[index]);
+                return classFromType(arguments[index], typeVariables);
             }
-            Class<?> resolved = genericArgument(rawClass, target, index);
+            Class<?> resolved = genericArgument(rawClass, target, index, typeVariables);
             if (resolved != null) {
                 return resolved;
             }
         }
-        return genericArgument(rawClass(type), target, index);
+        return genericArgument(rawClass(type), target, index, typeVariables);
     }
 
     private static Class<?> genericArgument(Class<?> type, Class<?> target, int index) {
+        return genericArgument(type, target, index, Map.of());
+    }
+
+    private static Class<?> genericArgument(
+            Class<?> type,
+            Class<?> target,
+            int index,
+            Map<TypeVariable<?>, Type> typeVariables) {
         if (type == null || Object.class.equals(type)) {
             return null;
         }
         for (Type interfaceType : type.getGenericInterfaces()) {
-            Class<?> resolved = genericArgument(interfaceType, target, index);
+            Class<?> resolved = genericArgument(interfaceType, target, index, typeVariables);
             if (resolved != null) {
                 return resolved;
             }
         }
-        return genericArgument(type.getGenericSuperclass(), target, index);
+        return genericArgument(type.getGenericSuperclass(), target, index, typeVariables);
     }
 
     private static Class<?> classFromType(Type type) {
+        return classFromType(type, Map.of());
+    }
+
+    private static Class<?> classFromType(Type type, Map<TypeVariable<?>, Type> typeVariables) {
+        Type substituted = substituteType(type, typeVariables);
+        if (!substituted.equals(type)) {
+            return classFromType(substituted, typeVariables);
+        }
         if (type instanceof Class<?> clazz) {
             return clazz;
         }
@@ -307,17 +349,120 @@ public final class SearchPath {
             return rawClass(parameterizedType.getRawType());
         }
         if (type instanceof GenericArrayType genericArrayType) {
-            Class<?> componentType = classFromType(genericArrayType.getGenericComponentType());
+            Class<?> componentType = classFromType(genericArrayType.getGenericComponentType(), typeVariables);
             return componentType == null ? null : Array.newInstance(componentType, 0).getClass();
         }
         if (type instanceof WildcardType wildcardType) {
             Type[] upperBounds = wildcardType.getUpperBounds();
-            return upperBounds.length == 0 ? null : classFromType(upperBounds[0]);
+            return upperBounds.length == 0 ? null : classFromType(upperBounds[0], typeVariables);
         }
-        if (type instanceof TypeVariable<?>) {
-            return null;
+        if (type instanceof TypeVariable<?> typeVariable) {
+            Type[] upperBounds = typeVariable.getBounds();
+            return upperBounds.length == 0 ? null : classFromType(upperBounds[0], typeVariables);
         }
         return null;
+    }
+
+    private static Map<TypeVariable<?>, Type> typeVariables(Class<?> owner, Class<?> declaringClass) {
+        if (owner == null || declaringClass == null) {
+            return Map.of();
+        }
+        Map<TypeVariable<?>, Type> mappings = new LinkedHashMap<>();
+        if (!resolveTypeVariables(owner, declaringClass, mappings)) {
+            return Map.of();
+        }
+        return Map.copyOf(mappings);
+    }
+
+    private static boolean resolveTypeVariables(
+            Type currentType,
+            Class<?> target,
+            Map<TypeVariable<?>, Type> mappings) {
+        Class<?> current = rawClass(currentType);
+        if (current == null) {
+            return false;
+        }
+        recordTypeVariables(currentType, current, mappings);
+        if (current.equals(target)) {
+            return true;
+        }
+        for (Type interfaceType : current.getGenericInterfaces()) {
+            Map<TypeVariable<?>, Type> branch = new LinkedHashMap<>(mappings);
+            if (resolveTypeVariables(substituteType(interfaceType, branch), target, branch)) {
+                mappings.clear();
+                mappings.putAll(branch);
+                return true;
+            }
+        }
+        Type superclass = current.getGenericSuperclass();
+        return superclass != null && resolveTypeVariables(substituteType(superclass, mappings), target, mappings);
+    }
+
+    private static void recordTypeVariables(
+            Type currentType,
+            Class<?> current,
+            Map<TypeVariable<?>, Type> mappings) {
+        if (currentType instanceof ParameterizedType parameterizedType) {
+            TypeVariable<?>[] variables = current.getTypeParameters();
+            Type[] arguments = parameterizedType.getActualTypeArguments();
+            for (int index = 0; index < variables.length && index < arguments.length; index++) {
+                mappings.put(variables[index], substituteType(arguments[index], mappings));
+            }
+        }
+    }
+
+    private static Type substituteType(Type type, Map<TypeVariable<?>, Type> mappings) {
+        if (type instanceof TypeVariable<?> variable) {
+            Type mapped = mappings.get(variable);
+            return mapped == null || mapped.equals(variable) ? variable : substituteType(mapped, mappings);
+        }
+        if (type instanceof ParameterizedType parameterizedType) {
+            Type[] arguments = parameterizedType.getActualTypeArguments();
+            Type[] substituted = new Type[arguments.length];
+            boolean changed = false;
+            for (int index = 0; index < arguments.length; index++) {
+                substituted[index] = substituteType(arguments[index], mappings);
+                changed = changed || !substituted[index].equals(arguments[index]);
+            }
+            if (!changed) {
+                return type;
+            }
+            return new ResolvedParameterizedType(
+                    parameterizedType.getOwnerType(),
+                    parameterizedType.getRawType(),
+                    substituted);
+        }
+        if (type instanceof GenericArrayType genericArrayType) {
+            Type originalComponent = genericArrayType.getGenericComponentType();
+            Type component = substituteType(originalComponent, mappings);
+            if (component.equals(originalComponent)) {
+                return type;
+            }
+            if (component instanceof Class<?> componentClass) {
+                return Array.newInstance(componentClass, 0).getClass();
+            }
+            return new ResolvedGenericArrayType(component);
+        }
+        if (type instanceof WildcardType wildcardType) {
+            Type[] originalUpperBounds = wildcardType.getUpperBounds();
+            Type[] originalLowerBounds = wildcardType.getLowerBounds();
+            Type[] upperBounds = originalUpperBounds.clone();
+            Type[] lowerBounds = originalLowerBounds.clone();
+            boolean changed = false;
+            for (int index = 0; index < upperBounds.length; index++) {
+                upperBounds[index] = substituteType(upperBounds[index], mappings);
+                changed = changed || !upperBounds[index].equals(originalUpperBounds[index]);
+            }
+            for (int index = 0; index < lowerBounds.length; index++) {
+                lowerBounds[index] = substituteType(lowerBounds[index], mappings);
+                changed = changed || !lowerBounds[index].equals(originalLowerBounds[index]);
+            }
+            if (!changed) {
+                return type;
+            }
+            return new ResolvedWildcardType(upperBounds, lowerBounds);
+        }
+        return type;
     }
 
     private static Class<?> rawClass(Type type) {
@@ -340,7 +485,8 @@ public final class SearchPath {
             Class<?> type,
             Type genericType,
             AnnotatedElement primary,
-            AnnotatedElement secondary) {
+            AnnotatedElement secondary,
+            Map<TypeVariable<?>, Type> typeVariables) {
         @SafeVarargs
         final boolean hasAnyAnnotation(Class<? extends java.lang.annotation.Annotation>... annotations) {
             for (Class<? extends java.lang.annotation.Annotation> annotation : annotations) {
@@ -350,6 +496,43 @@ public final class SearchPath {
                 }
             }
             return false;
+        }
+    }
+
+    private record ResolvedParameterizedType(Type ownerType, Type rawType, Type[] actualTypeArguments)
+            implements ParameterizedType {
+        @Override
+        public Type[] getActualTypeArguments() {
+            return actualTypeArguments.clone();
+        }
+
+        @Override
+        public Type getRawType() {
+            return rawType;
+        }
+
+        @Override
+        public Type getOwnerType() {
+            return ownerType;
+        }
+    }
+
+    private record ResolvedGenericArrayType(Type genericComponentType) implements GenericArrayType {
+        @Override
+        public Type getGenericComponentType() {
+            return genericComponentType;
+        }
+    }
+
+    private record ResolvedWildcardType(Type[] upperBounds, Type[] lowerBounds) implements WildcardType {
+        @Override
+        public Type[] getUpperBounds() {
+            return upperBounds.clone();
+        }
+
+        @Override
+        public Type[] getLowerBounds() {
+            return lowerBounds.clone();
         }
     }
 

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/definition/SearchPath.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/definition/SearchPath.java
@@ -21,6 +21,7 @@ import java.lang.reflect.WildcardType;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.springframework.beans.BeanUtils;
 import org.springframework.util.ClassUtils;
@@ -108,8 +109,18 @@ public final class SearchPath {
                 resolved.toManyPaths());
     }
 
+    /**
+     * Splits a dot-separated path while preserving empty leading, middle, and trailing segments.
+     *
+     * @param path dot-separated Java/JPA path
+     * @return path segments including malformed empty segments
+     */
+    public static String[] segments(String path) {
+        return Objects.requireNonNull(path, "path must not be null").split("\\.", -1);
+    }
+
     private static ResolvedPath resolve(Class<?> entity, String selector, String path, SearchPolicy.Paths limits) {
-        String[] segments = path.split("\\.");
+        String[] segments = segments(path);
         validateDepth(selector, path, limits, segments.length);
         Class<?> current = entity;
         boolean traversesCollection = false;

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/definition/SearchPath.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/definition/SearchPath.java
@@ -18,9 +18,11 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -266,10 +268,6 @@ public final class SearchPath {
                         typeVariables(owner, field.getDeclaringClass()));
     }
 
-    private static Class<?> collectionElementType(Class<?> type, Type genericType) {
-        return collectionElementType(type, genericType, Map.of());
-    }
-
     private static Class<?> collectionElementType(
             Class<?> type,
             Type genericType,
@@ -287,10 +285,6 @@ public final class SearchPath {
             return genericArgument(genericType, Iterable.class, 0, typeVariables);
         }
         return null;
-    }
-
-    private static Class<?> genericArgument(Type type, Class<?> target, int index) {
-        return genericArgument(type, target, index, Map.of());
     }
 
     private static Class<?> genericArgument(
@@ -312,10 +306,6 @@ public final class SearchPath {
         return genericArgument(rawClass(type), target, index, typeVariables);
     }
 
-    private static Class<?> genericArgument(Class<?> type, Class<?> target, int index) {
-        return genericArgument(type, target, index, Map.of());
-    }
-
     private static Class<?> genericArgument(
             Class<?> type,
             Class<?> target,
@@ -331,10 +321,6 @@ public final class SearchPath {
             }
         }
         return genericArgument(type.getGenericSuperclass(), target, index, typeVariables);
-    }
-
-    private static Class<?> classFromType(Type type) {
-        return classFromType(type, Map.of());
     }
 
     private static Class<?> classFromType(Type type, Map<TypeVariable<?>, Type> typeVariables) {
@@ -413,56 +399,68 @@ public final class SearchPath {
 
     private static Type substituteType(Type type, Map<TypeVariable<?>, Type> mappings) {
         if (type instanceof TypeVariable<?> variable) {
-            Type mapped = mappings.get(variable);
-            return mapped == null || mapped.equals(variable) ? variable : substituteType(mapped, mappings);
+            return substituteTypeVariable(variable, mappings);
         }
         if (type instanceof ParameterizedType parameterizedType) {
-            Type[] arguments = parameterizedType.getActualTypeArguments();
-            Type[] substituted = new Type[arguments.length];
-            boolean changed = false;
-            for (int index = 0; index < arguments.length; index++) {
-                substituted[index] = substituteType(arguments[index], mappings);
-                changed = changed || !substituted[index].equals(arguments[index]);
-            }
-            if (!changed) {
-                return type;
-            }
-            return new ResolvedParameterizedType(
-                    parameterizedType.getOwnerType(),
-                    parameterizedType.getRawType(),
-                    substituted);
+            return substituteParameterizedType(parameterizedType, mappings);
         }
         if (type instanceof GenericArrayType genericArrayType) {
-            Type originalComponent = genericArrayType.getGenericComponentType();
-            Type component = substituteType(originalComponent, mappings);
-            if (component.equals(originalComponent)) {
-                return type;
-            }
-            if (component instanceof Class<?> componentClass) {
-                return Array.newInstance(componentClass, 0).getClass();
-            }
-            return new ResolvedGenericArrayType(component);
+            return substituteGenericArrayType(genericArrayType, mappings);
         }
         if (type instanceof WildcardType wildcardType) {
-            Type[] originalUpperBounds = wildcardType.getUpperBounds();
-            Type[] originalLowerBounds = wildcardType.getLowerBounds();
-            Type[] upperBounds = originalUpperBounds.clone();
-            Type[] lowerBounds = originalLowerBounds.clone();
-            boolean changed = false;
-            for (int index = 0; index < upperBounds.length; index++) {
-                upperBounds[index] = substituteType(upperBounds[index], mappings);
-                changed = changed || !upperBounds[index].equals(originalUpperBounds[index]);
-            }
-            for (int index = 0; index < lowerBounds.length; index++) {
-                lowerBounds[index] = substituteType(lowerBounds[index], mappings);
-                changed = changed || !lowerBounds[index].equals(originalLowerBounds[index]);
-            }
-            if (!changed) {
-                return type;
-            }
-            return new ResolvedWildcardType(upperBounds, lowerBounds);
+            return substituteWildcardType(wildcardType, mappings);
         }
         return type;
+    }
+
+    private static Type substituteTypeVariable(TypeVariable<?> variable, Map<TypeVariable<?>, Type> mappings) {
+        Type mapped = mappings.get(variable);
+        return mapped == null || mapped.equals(variable) ? variable : substituteType(mapped, mappings);
+    }
+
+    private static Type substituteParameterizedType(
+            ParameterizedType type,
+            Map<TypeVariable<?>, Type> mappings) {
+        Type[] arguments = type.getActualTypeArguments();
+        Type[] substituted = substituteTypes(arguments, mappings);
+        if (Arrays.equals(arguments, substituted)) {
+            return type;
+        }
+        return new ResolvedParameterizedType(
+                type.getOwnerType(),
+                type.getRawType(),
+                substituted);
+    }
+
+    private static Type substituteGenericArrayType(
+            GenericArrayType type,
+            Map<TypeVariable<?>, Type> mappings) {
+        Type originalComponent = type.getGenericComponentType();
+        Type component = substituteType(originalComponent, mappings);
+        if (component.equals(originalComponent)) {
+            return type;
+        }
+        if (component instanceof Class<?> componentClass) {
+            return Array.newInstance(componentClass, 0).getClass();
+        }
+        return new ResolvedGenericArrayType(component);
+    }
+
+    private static Type substituteWildcardType(WildcardType type, Map<TypeVariable<?>, Type> mappings) {
+        Type[] upperBounds = substituteTypes(type.getUpperBounds(), mappings);
+        Type[] lowerBounds = substituteTypes(type.getLowerBounds(), mappings);
+        if (Arrays.equals(type.getUpperBounds(), upperBounds) && Arrays.equals(type.getLowerBounds(), lowerBounds)) {
+            return type;
+        }
+        return new ResolvedWildcardType(upperBounds, lowerBounds);
+    }
+
+    private static Type[] substituteTypes(Type[] types, Map<TypeVariable<?>, Type> mappings) {
+        Type[] substituted = types.clone();
+        for (int index = 0; index < substituted.length; index++) {
+            substituted[index] = substituteType(substituted[index], mappings);
+        }
+        return substituted;
     }
 
     private static Class<?> rawClass(Type type) {
@@ -499,11 +497,15 @@ public final class SearchPath {
         }
     }
 
-    private record ResolvedParameterizedType(Type ownerType, Type rawType, Type[] actualTypeArguments)
+    private record ResolvedParameterizedType(Type ownerType, Type rawType, List<Type> actualTypeArguments)
             implements ParameterizedType {
+        private ResolvedParameterizedType(Type ownerType, Type rawType, Type[] actualTypeArguments) {
+            this(ownerType, rawType, List.of(actualTypeArguments));
+        }
+
         @Override
         public Type[] getActualTypeArguments() {
-            return actualTypeArguments.clone();
+            return actualTypeArguments.toArray(Type[]::new);
         }
 
         @Override
@@ -524,15 +526,19 @@ public final class SearchPath {
         }
     }
 
-    private record ResolvedWildcardType(Type[] upperBounds, Type[] lowerBounds) implements WildcardType {
+    private record ResolvedWildcardType(List<Type> upperBounds, List<Type> lowerBounds) implements WildcardType {
+        private ResolvedWildcardType(Type[] upperBounds, Type[] lowerBounds) {
+            this(List.of(upperBounds), List.of(lowerBounds));
+        }
+
         @Override
         public Type[] getUpperBounds() {
-            return upperBounds.clone();
+            return upperBounds.toArray(Type[]::new);
         }
 
         @Override
         public Type[] getLowerBounds() {
-            return lowerBounds.clone();
+            return lowerBounds.toArray(Type[]::new);
         }
     }
 

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/filter/FilterOperator.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/filter/FilterOperator.java
@@ -15,7 +15,7 @@ import org.springframework.core.convert.ConversionService;
  *
  * @param <T> converted argument type
  */
-public final class FilterOperator<T> {
+public final class FilterOperator<T> implements AutoCloseable {
     private final RsqlOperator operator;
     private final Class<T> argumentType;
     private final HibernateRuleValidator<ArrayList<T>> args;
@@ -113,6 +113,13 @@ public final class FilterOperator<T> {
             cause = cause.getCause();
         }
         return false;
+    }
+
+    /** Releases validator resources owned by this operator. */
+    @Override
+    public void close() {
+        args.close();
+        each.close();
     }
 
     /**

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/filter/SearchFiltering.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/filter/SearchFiltering.java
@@ -20,7 +20,7 @@ import org.springframework.core.convert.ConversionService;
  *
  * @param <T> exposed field type
  */
-public final class SearchFiltering<T> {
+public final class SearchFiltering<T> implements AutoCloseable {
     private static final String OPERATOR_MUST_NOT_BE_NULL = "operator must not be null";
 
     private static final SearchFiltering<?> DISABLED =
@@ -151,6 +151,12 @@ public final class SearchFiltering<T> {
             return false;
         }
         return operators.get(operator).accepts(arguments, conversionService);
+    }
+
+    /** Releases validator resources owned by enabled operator declarations. */
+    @Override
+    public void close() {
+        operators.values().forEach(FilterOperator::close);
     }
 
     /**

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/jpa/JpaSearchDefinitionValidator.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/jpa/JpaSearchDefinitionValidator.java
@@ -2,6 +2,7 @@ package io.github.ggomarighetti.jparsqlsearch.jpa;
 
 import io.github.ggomarighetti.jparsqlsearch.definition.SearchDefinition;
 import io.github.ggomarighetti.jparsqlsearch.definition.SearchField;
+import io.github.ggomarighetti.jparsqlsearch.definition.SearchPath;
 import io.github.ggomarighetti.jparsqlsearch.exception.SearchDefinitionValidationException;
 import io.github.ggomarighetti.jparsqlsearch.validation.SearchDefinitionValidator;
 import jakarta.persistence.EntityManagerFactory;
@@ -73,7 +74,7 @@ public final class JpaSearchDefinitionValidator implements SearchDefinitionValid
     }
 
     private Class<?> resolve(Class<?> entity, String selector, String capability, String path) {
-        String[] segments = path.split("\\.");
+        String[] segments = SearchPath.segments(path);
         Class<?> current = entity;
         for (int index = 0; index < segments.length; index++) {
             ManagedType<?> managedType = managedType(entity, selector, capability, path, current);

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/page/SearchPaging.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/page/SearchPaging.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /** Definition-level Bean Validation rules for page number and page size. */
-public final class SearchPaging {
+public final class SearchPaging implements AutoCloseable {
     private static final SearchPaging DISABLED =
             new SearchPaging(false, HibernateRuleValidator.none(), HibernateRuleValidator.none());
 
@@ -102,6 +102,13 @@ public final class SearchPaging {
      */
     public List<RuleViolation> sizeViolations(int size) {
         return enabled ? this.size.violations(size) : List.of();
+    }
+
+    /** Releases validator resources owned by this paging declaration. */
+    @Override
+    public void close() {
+        page.close();
+        size.close();
     }
 
     /** Builder for definition-level paging rules. */

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/policy/SearchPolicy.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/policy/SearchPolicy.java
@@ -934,9 +934,9 @@ public final class SearchPolicy {
      * @param minSize minimum requested page size
      * @param maxSize maximum requested page size
      * @param maxOffset maximum accepted row offset
-     * @param allowUnpaged whether unpaged requests are allowed
-     * @param defaultUnpagedSize size used to bound an unpaged request
-     * @param maxUnpagedSize maximum size accepted for an unpaged request
+     * @param allowUnpaged whether unpaged requests are accepted and converted to a bounded first page
+     * @param defaultUnpagedSize page size used for converted unpaged requests
+     * @param maxUnpagedSize maximum configured size accepted for converted unpaged requests
      * @param page count-query limits
      * @param slice slice-query limits
      */
@@ -1070,9 +1070,9 @@ public final class SearchPolicy {
             }
 
             /**
-             * Enables or disables unpaged requests.
+             * Enables or disables bounded handling for unpaged requests.
              *
-             * @param allowUnpaged allowed state
+             * @param allowUnpaged whether unpaged requests are accepted and converted to a bounded first page
              * @return this builder
              */
             public Builder allowUnpaged(boolean allowUnpaged) {
@@ -1082,9 +1082,9 @@ public final class SearchPolicy {
             }
 
             /**
-             * Sets the size used to bound an unpaged request.
+             * Sets the page size used when an accepted unpaged request is converted to a bounded first page.
              *
-             * @param defaultUnpagedSize positive size
+             * @param defaultUnpagedSize positive page size
              * @return this builder
              */
             public Builder defaultUnpagedSize(int defaultUnpagedSize) {
@@ -1094,9 +1094,9 @@ public final class SearchPolicy {
             }
 
             /**
-             * Sets the size used to bound an unpaged request.
+             * Sets the page size used when an accepted unpaged request is converted to a bounded first page.
              *
-             * @param unpagedSize positive size
+             * @param unpagedSize positive page size
              * @return this builder
              */
             public Builder unpagedSize(int unpagedSize) {

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/query/SearchQuery.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/query/SearchQuery.java
@@ -13,7 +13,7 @@ import org.springframework.data.jpa.domain.Specification;
  *
  * @param <T> entity type targeted by the generated specification
  */
-public final class SearchQuery<T> {
+public final class SearchQuery<T> implements AutoCloseable {
     private static final SearchQuery<?> DISABLED =
             new SearchQuery<>(false, HibernateRuleValidator.none(), false, null);
 
@@ -104,6 +104,12 @@ public final class SearchQuery<T> {
             throw new IllegalStateException("query is disabled");
         }
         return specification.toSpecification(query);
+    }
+
+    /** Releases validator resources owned by this query declaration. */
+    @Override
+    public void close() {
+        validator.close();
     }
 
     /**

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/rsql/RsqlAst.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/rsql/RsqlAst.java
@@ -36,8 +36,9 @@ public final class RsqlAst {
                         descriptor.operator(),
                         comparison.getArguments()));
             } else if (current instanceof LogicalNode logical) {
-                for (Node child : logical.getChildren()) {
-                    stack.push(child);
+                List<Node> children = logical.getChildren();
+                for (int index = children.size() - 1; index >= 0; index--) {
+                    stack.push(children.get(index));
                 }
             }
         }
@@ -54,7 +55,7 @@ public final class RsqlAst {
     }
 
     /**
-     * Returns the normalized comparison view.
+     * Returns the normalized comparison view in left-to-right RSQL order.
      *
      * @return immutable normalized comparisons contained in the tree
      */

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/rsql/SearchRsqlEngineBuilder.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/rsql/SearchRsqlEngineBuilder.java
@@ -26,6 +26,17 @@ public final class SearchRsqlEngineBuilder {
     }
 
     /**
+     * Removes the default operator descriptors so callers can build a custom dialect
+     * from an empty registry.
+     *
+     * @return this builder
+     */
+    public SearchRsqlEngineBuilder withoutDefaultOperators() {
+        operators.clear();
+        return this;
+    }
+
+    /**
      * Adds one operator descriptor.
      *
      * @param descriptor operator descriptor

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
@@ -52,7 +52,9 @@ public final class PerplexhubRsqlBackendAdapter implements RsqlBackendAdapter {
     @Override
     public <T> Specification<T> compile(RsqlCompilationRequest<T> request) {
         return (root, query, criteriaBuilder) -> {
-            query.distinct(request.distinct());
+            if (request.distinct()) {
+                query.distinct(true);
+            }
             PredicateContext context = new PredicateContext(request, root, criteriaBuilder);
             return context.predicate(request.ast().node());
         };

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapter.java
@@ -72,7 +72,14 @@ public final class PerplexhubRsqlBackendAdapter implements RsqlBackendAdapter {
             if (descriptor.jpaPredicateFactory().isPresent() && descriptor.argumentType().isEmpty()) {
                 throw new SearchDefinitionValidationException(
                         SearchDefinitionValidationException.RSQL_OPERATOR_TYPE_MISMATCH,
-                        "custom operator '%s' must declare a Comparable argument type".formatted(operator));
+                        "custom operator '%s' must declare an argument type".formatted(operator));
+            }
+            if (descriptor.jpaPredicateFactory().isPresent()
+                    && !Comparable.class.isAssignableFrom(descriptor.argumentType().orElseThrow())) {
+                throw new SearchDefinitionValidationException(
+                        SearchDefinitionValidationException.RSQL_OPERATOR_TYPE_MISMATCH,
+                        "custom operator '%s' must declare a Comparable argument type for the Perplexhub backend"
+                                .formatted(operator));
             }
         }
     }
@@ -90,13 +97,18 @@ public final class PerplexhubRsqlBackendAdapter implements RsqlBackendAdapter {
     private static RSQLCustomPredicate<?> customPredicate(
             RsqlOperatorDescriptor descriptor,
             RsqlJpaPredicateFactory factory) {
-        Class<? extends Comparable<?>> type = descriptor.argumentType().orElse(String.class);
+        Class<? extends Comparable<?>> type = comparableType(descriptor.argumentType().orElse(String.class));
         Function<RSQLCustomPredicateInput, Predicate> converter =
                 input -> factory.toPredicate(context(input, descriptor.operator()));
         return new RSQLCustomPredicate(
                 descriptor.comparisonOperator(),
                 type,
                 converter);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<? extends Comparable<?>> comparableType(Class<?> type) {
+        return (Class<? extends Comparable<?>>) type.asSubclass(Comparable.class);
     }
 
     private static RsqlJpaPredicateContext<?, ?, ?, ?, ?> context(RSQLCustomPredicateInput input, RsqlOperator operator) {

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/rsql/operator/RsqlOperatorDescriptor.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/rsql/operator/RsqlOperatorDescriptor.java
@@ -14,7 +14,7 @@ public final class RsqlOperatorDescriptor {
     private final RsqlOperator operator;
     private final Set<String> symbols;
     private final RsqlOperatorArity arity;
-    private final Class<? extends Comparable<?>> argumentType;
+    private final Class<?> argumentType;
     private final RsqlJpaPredicateFactory jpaPredicateFactory;
     private final boolean defaultJpaSupported;
 
@@ -22,7 +22,7 @@ public final class RsqlOperatorDescriptor {
             RsqlOperator operator,
             Set<String> symbols,
             RsqlOperatorArity arity,
-            Class<? extends Comparable<?>> argumentType,
+            Class<?> argumentType,
             RsqlJpaPredicateFactory jpaPredicateFactory,
             boolean defaultJpaSupported) {
         this.operator = Objects.requireNonNull(operator, "operator must not be null");
@@ -96,7 +96,7 @@ public final class RsqlOperatorDescriptor {
      *
      * @return explicit conversion type for custom execution
      */
-    public Optional<Class<? extends Comparable<?>>> argumentType() {
+    public Optional<Class<?>> argumentType() {
         return Optional.ofNullable(argumentType);
     }
 
@@ -132,7 +132,7 @@ public final class RsqlOperatorDescriptor {
         private final RsqlOperator operator;
         private final Set<String> symbols = new LinkedHashSet<>();
         private RsqlOperatorArity arity = RsqlOperatorArity.exact(1);
-        private Class<? extends Comparable<?>> argumentType;
+        private Class<?> argumentType;
         private RsqlJpaPredicateFactory jpaPredicateFactory;
         private boolean defaultJpaSupported;
 
@@ -190,10 +190,10 @@ public final class RsqlOperatorDescriptor {
         /**
          * Configures the conversion type used by a custom predicate.
          *
-         * @param argumentType comparable conversion type
+         * @param argumentType conversion type
          * @return this builder
          */
-        public Builder argumentType(Class<? extends Comparable<?>> argumentType) {
+        public Builder argumentType(Class<?> argumentType) {
             this.argumentType = Objects.requireNonNull(argumentType, "argumentType must not be null");
             return this;
         }

--- a/src/main/java/io/github/ggomarighetti/jparsqlsearch/validation/HibernateRuleValidator.java
+++ b/src/main/java/io/github/ggomarighetti/jparsqlsearch/validation/HibernateRuleValidator.java
@@ -17,7 +17,7 @@ import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator
  *
  * @param <T> validated value type
  */
-public final class HibernateRuleValidator<T> {
+public final class HibernateRuleValidator<T> implements AutoCloseable {
     private static final Cleaner CLEANER = Cleaner.create();
     private static final HibernateRuleValidator<?> NONE = new HibernateRuleValidator<>(null, null);
 
@@ -91,6 +91,19 @@ public final class HibernateRuleValidator<T> {
                         .thenComparing(RuleViolation::constraint)
                         .thenComparing(RuleViolation::message))
                 .toList();
+    }
+
+    /**
+     * Releases the underlying validator factory, when this validator owns one.
+     *
+     * <p>Reusable static validators created with {@link #none()} do not own resources
+     * and closing them is a no-op. Closing is idempotent.
+     */
+    @Override
+    public void close() {
+        if (cleanable != null) {
+            cleanable.clean();
+        }
     }
 
     private static RuleViolation toViolation(ConstraintViolation<?> violation) {

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/autoconfigure/JpaRsqlSearchAutoConfigurationTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/autoconfigure/JpaRsqlSearchAutoConfigurationTest.java
@@ -4,6 +4,7 @@ import io.github.ggomarighetti.jparsqlsearch.compile.SearchCompiler;
 import io.github.ggomarighetti.jparsqlsearch.definition.SearchDefinition;
 import io.github.ggomarighetti.jparsqlsearch.definition.SearchDefinitionFactory;
 import io.github.ggomarighetti.jparsqlsearch.exception.SearchProtectionException;
+import io.github.ggomarighetti.jparsqlsearch.rsql.SearchRsqlEngine;
 import io.github.ggomarighetti.jparsqlsearch.unit.TestTypes;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -26,6 +27,30 @@ class JpaRsqlSearchAutoConfigurationTest {
     @Test
     void createsSearchCompilerBean() {
         contextRunner.run(context -> assertNotNull(context.getBean(SearchCompiler.class)));
+    }
+
+    @Test
+    void backsOffCompilerWhenDefaultRsqlEngineIsDisabled() {
+        contextRunner
+                .withPropertyValues("jpa.rsql.search.rsql.enabled=false")
+                .run(context -> {
+                    assertTrue(context.containsBean("searchDefinitionFactory"));
+                    assertFalse(context.containsBean("searchRsqlEngine"));
+                    assertFalse(context.containsBean("searchCompiler"));
+                });
+    }
+
+    @Test
+    void createsCompilerWithUserProvidedEngineWhenDefaultRsqlEngineIsDisabled() {
+        SearchRsqlEngine engine = SearchRsqlEngine.defaults();
+
+        contextRunner
+                .withPropertyValues("jpa.rsql.search.rsql.enabled=false")
+                .withBean(SearchRsqlEngine.class, () -> engine)
+                .run(context -> {
+                    assertTrue(context.containsBean("searchCompiler"));
+                    assertNotNull(context.getBean(SearchCompiler.class));
+                });
     }
 
     @Test

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/compile/RsqlSearchGuardTest.java
@@ -692,6 +692,63 @@ class RsqlSearchGuardTest {
     }
 
     @Test
+    void appliesProtectionBeforeDisallowedOperatorErrorsForDeclaredSelectors() {
+        SearchDefinition<TestTypes.Product> definition = filters(limits -> limits
+                .filter(filter -> filter.maxArgumentLength(5)));
+
+        SearchProtectionException exception = assertThrows(
+                SearchProtectionException.class,
+                () -> guard.specification("taxId!=20123456789", definition));
+
+        assertProtectionRule(exception, "filter.max-argument-length");
+    }
+
+    @Test
+    void appliesProtectionBeforeArgumentValidationErrors() {
+        SearchDefinition<TestTypes.Product> definition = filters(limits -> limits
+                .filter(filter -> filter.maxArgumentLength(2)));
+
+        SearchProtectionException exception = assertThrows(
+                SearchProtectionException.class,
+                () -> guard.specification("taxId==abc", definition));
+
+        assertProtectionRule(exception, "filter.max-argument-length");
+    }
+
+    @Test
+    void appliesProtectionBeforeInvalidArityErrors() throws ReflectiveOperationException {
+        RsqlOperator pair = RsqlOperator.of("PAIR");
+        RsqlOperatorDescriptor descriptor = RsqlOperatorDescriptor.builder(pair)
+                .symbol("=pair=")
+                .arity(RsqlOperatorArity.exact(2))
+                .argumentType(String.class)
+                .jpaPredicate(context -> context.criteriaBuilder().conjunction())
+                .build();
+        SearchPolicy policy = SearchPolicy.builder()
+                .filter(filter -> filter.maxArgumentLength(5))
+                .build();
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder(policy).entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class)
+                        .filterable(filter -> filter.allow(pair, String.class, operator -> {})))
+                .build();
+        RsqlRulesValidator validator = new RsqlRulesValidator(
+                definition,
+                ApplicationConversionService.getSharedInstance(),
+                policy.rsql(),
+                new SearchProtectionContext(policy, SearchCompilationMode.PAGE),
+                new RsqlOperatorRegistry(List.of(descriptor)));
+
+        SearchProtectionException exception = assertThrows(
+                SearchProtectionException.class,
+                () -> validator.validate(ast(new ComparisonNode(
+                        new ComparisonOperator("=pair=", true),
+                        "email",
+                        List.of("person@example.com")))));
+
+        assertProtectionRule(exception, "filter.max-argument-length");
+    }
+
+    @Test
     void unrelatedLocalOverridePreservesGlobalArgumentLimit() {
         SearchPolicy globalPolicy = SearchPolicy.builder()
                 .filter(filter -> filter.maxArgumentsPerComparison(10))

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/compile/RsqlSearchGuardTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/compile/RsqlSearchGuardTest.java
@@ -716,7 +716,7 @@ class RsqlSearchGuardTest {
     }
 
     @Test
-    void appliesProtectionBeforeInvalidArityErrors() throws ReflectiveOperationException {
+    void appliesProtectionBeforeInvalidArityErrors() {
         RsqlOperator pair = RsqlOperator.of("PAIR");
         RsqlOperatorDescriptor descriptor = RsqlOperatorDescriptor.builder(pair)
                 .symbol("=pair=")
@@ -737,13 +737,14 @@ class RsqlSearchGuardTest {
                 policy.rsql(),
                 new SearchProtectionContext(policy, SearchCompilationMode.PAGE),
                 new RsqlOperatorRegistry(List.of(descriptor)));
+        RsqlAst comparison = astUnchecked(new ComparisonNode(
+                new ComparisonOperator("=pair=", true),
+                "email",
+                List.of("person@example.com")));
 
         SearchProtectionException exception = assertThrows(
                 SearchProtectionException.class,
-                () -> validator.validate(ast(new ComparisonNode(
-                        new ComparisonOperator("=pair=", true),
-                        "email",
-                        List.of("person@example.com")))));
+                () -> validator.validate(comparison));
 
         assertProtectionRule(exception, "filter.max-argument-length");
     }
@@ -830,6 +831,14 @@ class RsqlSearchGuardTest {
         Constructor<RsqlAst> constructor = RsqlAst.class.getDeclaredConstructor(Node.class, List.class);
         constructor.setAccessible(true);
         return constructor.newInstance(node, List.of());
+    }
+
+    private static RsqlAst astUnchecked(Node node) {
+        try {
+            return ast(node);
+        } catch (ReflectiveOperationException exception) {
+            throw new AssertionError(exception);
+        }
     }
 
     private static final class UnsupportedNode implements Node {

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/rsql/RsqlAstTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/rsql/RsqlAstTest.java
@@ -32,6 +32,15 @@ class RsqlAstTest {
         assertEquals(List.of(), ast.comparisons());
     }
 
+    @Test
+    void preservesLeftToRightComparisonOrder() {
+        RsqlAst ast = SearchRsqlEngine.defaults().parse("email==a;name==b;taxId==c");
+
+        assertEquals(
+                List.of("email", "name", "taxId"),
+                ast.comparisons().stream().map(RsqlComparison::selector).toList());
+    }
+
     private static final class UnsupportedNode implements Node {
         @Override
         public <R, A> R accept(RSQLVisitor<R, A> visitor, A param) {

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapterTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/rsql/backend/perplexhub/PerplexhubRsqlBackendAdapterTest.java
@@ -13,13 +13,16 @@ import jakarta.persistence.criteria.Root;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.convert.ApplicationConversionService;
 
 import static io.github.ggomarighetti.jparsqlsearch.rsql.operator.RsqlOperators.EQUAL;
 import static io.github.ggomarighetti.jparsqlsearch.unit.ExceptionAssertions.thrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PerplexhubRsqlBackendAdapterTest {
     private final PerplexhubRsqlBackendAdapter adapter = new PerplexhubRsqlBackendAdapter();
@@ -53,15 +56,57 @@ class PerplexhubRsqlBackendAdapterTest {
                 () -> adapter.compile(request).toPredicate(root(), query(), criteriaBuilder())));
     }
 
+    @Test
+    void preservesExistingDistinctWhenRequestDoesNotRequireDistinct() throws Exception {
+        RsqlAst ast = ast(new UnsupportedNode());
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class)
+                        .filterable(filter -> filter.allow(EQUAL)))
+                .build();
+        RsqlCompilationRequest<TestTypes.Product> request = request("email==value", ast, definition, false);
+        RecordingCriteriaQuery query = new RecordingCriteriaQuery();
+
+        assertNotNull(thrownBy(
+                IllegalArgumentException.class,
+                () -> adapter.compile(request).toPredicate(root(), query.proxy(), criteriaBuilder())));
+
+        assertTrue(query.distinctValues.isEmpty());
+    }
+
+    @Test
+    void enablesDistinctOnlyWhenRequestRequiresDistinct() throws Exception {
+        RsqlAst ast = ast(new UnsupportedNode());
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class)
+                        .filterable(filter -> filter.allow(EQUAL)))
+                .build();
+        RsqlCompilationRequest<TestTypes.Product> request = request("email==value", ast, definition, true);
+        RecordingCriteriaQuery query = new RecordingCriteriaQuery();
+
+        assertNotNull(thrownBy(
+                IllegalArgumentException.class,
+                () -> adapter.compile(request).toPredicate(root(), query.proxy(), criteriaBuilder())));
+
+        assertEquals(List.of(true), query.distinctValues);
+    }
+
     private RsqlCompilationRequest<TestTypes.Product> request(
             String rsql,
             RsqlAst ast,
             SearchDefinition<TestTypes.Product> definition) {
+        return request(rsql, ast, definition, false);
+    }
+
+    private RsqlCompilationRequest<TestTypes.Product> request(
+            String rsql,
+            RsqlAst ast,
+            SearchDefinition<TestTypes.Product> definition,
+            boolean distinct) {
         return new RsqlCompilationRequest<>(
                 rsql,
                 ast,
                 definition,
-                false,
+                distinct,
                 ApplicationConversionService.getSharedInstance(),
                 engine.operators());
     }
@@ -121,6 +166,20 @@ class PerplexhubRsqlBackendAdapterTest {
             return '\0';
         }
         return 0;
+    }
+
+    private static final class RecordingCriteriaQuery {
+        private final List<Boolean> distinctValues = new ArrayList<>();
+
+        private CriteriaQuery<?> proxy() {
+            return PerplexhubRsqlBackendAdapterTest.proxy(CriteriaQuery.class, (proxy, method, args) -> {
+                if ("distinct".equals(method.getName())) {
+                    distinctValues.add((Boolean) args[0]);
+                    return proxy;
+                }
+                return defaultValue(method.getReturnType());
+            });
+        }
     }
 
     private static final class UnsupportedNode implements Node {

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/JpaSearchDefinitionValidatorTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/JpaSearchDefinitionValidatorTest.java
@@ -53,6 +53,27 @@ class JpaSearchDefinitionValidatorTest {
     }
 
     @Test
+    void rejectsTrailingEmptyPathSegmentsAgainstMetamodel() throws Exception {
+        Method resolve = JpaSearchDefinitionValidator.class.getDeclaredMethod(
+                "resolve",
+                Class.class,
+                String.class,
+                String.class,
+                String.class);
+        resolve.setAccessible(true);
+        ManagedType<?> product = managedType(Map.of("email", attribute(String.class, false)));
+        JpaSearchDefinitionValidator validator = validator(Map.of(TestTypes.Product.class, product));
+
+        InvocationTargetException exception = thrownBy(
+                InvocationTargetException.class,
+                () -> resolve.invoke(validator, TestTypes.Product.class, "email", "filtering", "email."));
+
+        assertEquals(
+                SearchDefinitionValidationException.JPA_PATH_UNRESOLVED,
+                ((SearchDefinitionValidationException) exception.getCause()).code());
+    }
+
+    @Test
     void rejectsCollectionAttributeThatIsNotPluralAttribute() {
         SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder()
                 .entity(TestTypes.Product.class)

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/PublicApiSurfaceTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/PublicApiSurfaceTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.github.ggomarighetti.jparsqlsearch.policy.SearchPolicy;
 import io.github.ggomarighetti.jparsqlsearch.rsql.RsqlCompilationRequest;
 import io.github.ggomarighetti.jparsqlsearch.rsql.SearchRsqlEngine;
+import io.github.ggomarighetti.jparsqlsearch.rsql.SearchRsqlEngineBuilder;
 import java.lang.reflect.Modifier;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -49,6 +50,8 @@ class PublicApiSurfaceTest {
                 SearchRsqlEngine.class.getMethod("parse", String.class).getModifiers()));
         assertTrue(Modifier.isPublic(
                 SearchRsqlEngine.class.getMethod("compile", RsqlCompilationRequest.class).getModifiers()));
+        assertTrue(Modifier.isPublic(
+                SearchRsqlEngineBuilder.class.getMethod("withoutDefaultOperators").getModifiers()));
         assertTrue(Modifier.isPublic(
                 SearchPolicy.Builder.class.getMethod("buildOverlay").getModifiers()));
     }

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/RsqlEngineCoverageTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/RsqlEngineCoverageTest.java
@@ -45,6 +45,19 @@ class RsqlEngineCoverageTest {
     }
 
     @Test
+    void builderCanStartWithoutDefaultOperators() {
+        SearchRsqlEngine engine = SearchRsqlEngine.builder()
+                .withoutDefaultOperators()
+                .operator(RsqlOperatorDescriptor.of(CUSTOM, "=custom="))
+                .backend(new NoOpBackend())
+                .build();
+
+        assertFalse(engine.operators().descriptor(EQUAL).isPresent());
+        assertTrue(engine.operators().descriptor(CUSTOM).isPresent());
+        assertNotNull(engine.parse("email=custom=value"));
+    }
+
+    @Test
     void parsedAstExposesNormalizedComparisonsForLogicalExpressions() {
         var ast = SearchRsqlEngine.defaults().parse("email==a;name==b");
 

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/RsqlEngineCoverageTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/RsqlEngineCoverageTest.java
@@ -109,6 +109,24 @@ class RsqlEngineCoverageTest {
     }
 
     @Test
+    void validateAllowsNonComparableArgumentTypesWithCustomBackends() {
+        ApplicationConversionService conversionService = new ApplicationConversionService();
+        conversionService.addConverter(String.class, Token.class, Token::new);
+        SearchDefinition<TestTypes.Product> definition = definition(CUSTOM, Token.class);
+        SearchRsqlEngine engine = SearchRsqlEngine.builder()
+                .withoutDefaultOperators()
+                .operator(RsqlOperatorDescriptor.builder(CUSTOM)
+                        .symbol("=token=")
+                        .argumentType(Token.class)
+                        .build())
+                .backend(new NoOpBackend())
+                .conversionService(conversionService)
+                .build();
+
+        engine.validate(definition);
+    }
+
+    @Test
     void validateAllowsStringArgumentTypesWithoutRegisteredStringConverter() {
         SearchDefinition<TestTypes.Product> definition = definition(CUSTOM, String.class);
         SearchRsqlEngine engine = SearchRsqlEngine.builder()
@@ -151,6 +169,26 @@ class RsqlEngineCoverageTest {
         assertEquals(SearchDefinitionValidationException.RSQL_OPERATOR_TYPE_MISMATCH, exception.code());
     }
 
+    @Test
+    void perplexhubRequiresComparableCustomArgumentTypes() {
+        RsqlOperatorDescriptor descriptor = RsqlOperatorDescriptor.builder(CUSTOM)
+                .symbol("=custom=")
+                .argumentType(Token.class)
+                .jpaPredicate(context -> null)
+                .build();
+        SearchRsqlEngine engine = SearchRsqlEngine.builder()
+                .operator(descriptor)
+                .backend(new NoOpBackend())
+                .build();
+        SearchDefinition<TestTypes.Product> definition = definition(CUSTOM, Token.class);
+
+        SearchDefinitionValidationException exception = thrownBy(
+                SearchDefinitionValidationException.class,
+                () -> new PerplexhubRsqlBackendAdapter().validate(engine, definition));
+
+        assertEquals(SearchDefinitionValidationException.RSQL_OPERATOR_TYPE_MISMATCH, exception.code());
+    }
+
     private static <A> SearchDefinition<TestTypes.Product> definition(RsqlOperator operator, Class<A> argumentType) {
         return SearchDefinition.builder()
                 .entity(TestTypes.Product.class)
@@ -159,11 +197,10 @@ class RsqlEngineCoverageTest {
                 .build();
     }
 
-    private static final class NoConversion implements Comparable<NoConversion> {
-        @Override
-        public int compareTo(NoConversion other) {
-            return 0;
-        }
+    private record Token(String value) {
+    }
+
+    private static final class NoConversion {
     }
 
     private static final class NoOpBackend implements RsqlBackendAdapter {

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/SearchDefinitionTest.java
@@ -15,6 +15,7 @@ import org.hibernate.validator.cfg.defs.SizeDef;
 import org.junit.jupiter.api.Test;
 import static io.github.ggomarighetti.jparsqlsearch.rsql.operator.RsqlOperators.EQUAL;
 import static io.github.ggomarighetti.jparsqlsearch.rsql.operator.RsqlOperators.IN;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -491,6 +492,22 @@ class SearchDefinitionTest {
         assertTrue(definition.query().accepts("abc"));
         assertTrue(definition.paging().accepts(0, 100));
         assertFalse(definition.paging().accepts(0, 101));
+    }
+
+    @Test
+    void closesRuleValidatorsIdempotentlyForDynamicDefinitions() {
+        SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class)
+                        .filterable(filter -> filter.allow(EQUAL, operator -> operator
+                                .each(each -> each.rule(new SizeDef().min(3))))))
+                .query(query -> query
+                        .rule(new SizeDef().min(3))
+                        .specification(term -> (root, criteria, builder) -> builder.conjunction()))
+                .paging(paging -> paging.size(size -> size.rule(new MaxDef().value(100))))
+                .build();
+
+        assertDoesNotThrow(definition::close);
+        assertDoesNotThrow(definition::close);
     }
 
     @Test

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/SearchDefinitionTest.java
@@ -57,6 +57,28 @@ class SearchDefinitionTest {
     }
 
     @Test
+    void rejectsMalformedFieldFilteringAndSortingPaths() {
+        thrownBy(IllegalArgumentException.class, () ->
+                SearchDefinition.builder().entity(TestTypes.Product.class)
+                        .fields(fields -> fields.add("email", String.class)
+                                .path("email.")
+                                .filterable(filter -> filter.allow(EQUAL)))
+                        .build());
+        thrownBy(IllegalArgumentException.class, () ->
+                SearchDefinition.builder().entity(TestTypes.Product.class)
+                        .fields(fields -> fields.add("email", String.class)
+                                .filterable(filter -> filter
+                                        .path(".email")
+                                        .allow(EQUAL)))
+                        .build());
+        thrownBy(IllegalArgumentException.class, () ->
+                SearchDefinition.builder().entity(TestTypes.Product.class)
+                        .fields(fields -> fields.add("email", String.class)
+                                .sortable(sort -> sort.path("email.")))
+                        .build());
+    }
+
+    @Test
     void validatesFieldPathAgainstDeclaredEntitySubtype() {
         SearchDefinition<TestTypes.Product> definition = SearchDefinition.builder().entity(TestTypes.Product.class)
                 .fields(fields -> fields.add("expiresAt", java.time.Instant.class)

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/SearchDefinitionTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/SearchDefinitionTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static io.github.ggomarighetti.jparsqlsearch.unit.ExceptionAssertions.thrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.data.domain.Sort.Direction.ASC;
 import static org.springframework.data.domain.Sort.Direction.DESC;
@@ -59,24 +60,9 @@ class SearchDefinitionTest {
 
     @Test
     void rejectsMalformedFieldFilteringAndSortingPaths() {
-        thrownBy(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("email", String.class)
-                                .path("email.")
-                                .filterable(filter -> filter.allow(EQUAL)))
-                        .build());
-        thrownBy(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("email", String.class)
-                                .filterable(filter -> filter
-                                        .path(".email")
-                                        .allow(EQUAL)))
-                        .build());
-        thrownBy(IllegalArgumentException.class, () ->
-                SearchDefinition.builder().entity(TestTypes.Product.class)
-                        .fields(fields -> fields.add("email", String.class)
-                                .sortable(sort -> sort.path("email.")))
-                        .build());
+        assertThrows(IllegalArgumentException.class, SearchDefinitionTest::buildFieldWithMalformedDefaultPath);
+        assertThrows(IllegalArgumentException.class, SearchDefinitionTest::buildFieldWithMalformedFilteringPath);
+        assertThrows(IllegalArgumentException.class, SearchDefinitionTest::buildFieldWithMalformedSortingPath);
     }
 
     @Test
@@ -713,6 +699,30 @@ class SearchDefinitionTest {
         builder.fields(fields -> fields.add("expiresAt", java.time.Instant.class)
                 .subtype(String.class)
                 .filterable(filter -> filter.allow(EQUAL)));
+    }
+
+    private static void buildFieldWithMalformedDefaultPath() {
+        SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class)
+                        .path("email.")
+                        .filterable(filter -> filter.allow(EQUAL)))
+                .build();
+    }
+
+    private static void buildFieldWithMalformedFilteringPath() {
+        SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class)
+                        .filterable(filter -> filter
+                                .path(".email")
+                                .allow(EQUAL)))
+                .build();
+    }
+
+    private static void buildFieldWithMalformedSortingPath() {
+        SearchDefinition.builder().entity(TestTypes.Product.class)
+                .fields(fields -> fields.add("email", String.class)
+                        .sortable(sort -> sort.path("email.")))
+                .build();
     }
 
     private static void declareDuplicateQuery(

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/SearchPathTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/SearchPathTest.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static io.github.ggomarighetti.jparsqlsearch.unit.ExceptionAssertions.thrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -79,6 +78,27 @@ class SearchPathTest {
     }
 
     @Test
+    void resolvesCollectionElementTypesFromGenericBoundsAndConcreteSupertypes() {
+        SearchPath.Metadata bounded = SearchPath.metadata(
+                GenericRoot.class,
+                "sku",
+                "genericLines.sku",
+                String.class,
+                DEEP_PATHS);
+        SearchPath.Metadata concrete = SearchPath.metadata(
+                ConcreteGenericRoot.class,
+                "sku",
+                "concreteLines.sku",
+                String.class,
+                DEEP_PATHS);
+
+        assertEquals(String.class, bounded.type());
+        assertTrue(bounded.traversesCollection());
+        assertEquals(String.class, concrete.type());
+        assertTrue(concrete.traversesCollection());
+    }
+
+    @Test
     void reportsTerminalCollectionMetadataWithoutTraversingThroughIt() {
         SearchPath.Metadata array = SearchPath.metadata(
                 CollectionRoot.class,
@@ -103,9 +123,6 @@ class SearchPathTest {
 
     @Test
     void rejectsCollectionPathsWhenElementTypeCannotResolveToAPropertyOwner() {
-        assertNotNull(thrownBy(
-                IllegalArgumentException.class,
-                () -> SearchPath.metadata(GenericRoot.class, "sku", "genericLines.sku", String.class, DEEP_PATHS)));
         thrownBy(
                 IllegalArgumentException.class,
                 () -> SearchPath.metadata(GenericRoot.class, "sku", "nestedLines.sku", String.class, DEEP_PATHS));
@@ -222,7 +239,7 @@ class SearchPathTest {
         assertNull(genericArgumentFromClass.invoke(null, Object.class, Iterable.class, 0));
         assertEquals(String[].class, classFromType.invoke(null, genericArray(String.class)));
         assertNull(classFromType.invoke(null, wildcardWithoutUpperBounds()));
-        assertNull(classFromType.invoke(null, GenericRoot.class.getTypeParameters()[0]));
+        assertEquals(Line.class, classFromType.invoke(null, GenericRoot.class.getTypeParameters()[0]));
         assertNull(classFromType.invoke(null, new UnknownType()));
         assertEquals(List.class, rawClass.invoke(null, parameterized(List.class, String.class)));
     }
@@ -378,7 +395,19 @@ class SearchPathTest {
         }
     }
 
-    private static final class Line {
+    private static class GenericBase<T extends Line> {
+        public List<T> getConcreteLines() {
+            return List.of();
+        }
+    }
+
+    private static final class ConcreteGenericRoot extends GenericBase<SpecialLine> {
+    }
+
+    private static final class SpecialLine extends Line {
+    }
+
+    private static class Line {
         public String getSku() {
             return null;
         }

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/SearchPathTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/SearchPathTest.java
@@ -121,7 +121,24 @@ class SearchPathTest {
     void rejectsBlankMissingAndTooDeepSegments() {
         thrownBy(
                 IllegalArgumentException.class,
+                () -> SearchPath.metadata(TestTypes.Product.class, "name", ".name", String.class, DEEP_PATHS));
+        thrownBy(
+                IllegalArgumentException.class,
+                () -> SearchPath.metadata(TestTypes.Product.class, "name", "name.", String.class, DEEP_PATHS));
+        thrownBy(
+                IllegalArgumentException.class,
+                () -> SearchPath.metadata(TestTypes.Product.class, "name", ".", String.class, DEEP_PATHS));
+        thrownBy(
+                IllegalArgumentException.class,
                 () -> SearchPath.metadata(TestTypes.Product.class, "name", "customer..name", String.class, DEEP_PATHS));
+        thrownBy(
+                IllegalArgumentException.class,
+                () -> SearchPath.metadata(
+                        TestTypes.Product.class,
+                        "name",
+                        "customer.name.",
+                        String.class,
+                        DEEP_PATHS));
         thrownBy(
                 IllegalArgumentException.class,
                 () -> SearchPath.metadata(TestTypes.Product.class, "missing", "missing", String.class, DEEP_PATHS));

--- a/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/SearchPathTest.java
+++ b/src/test/java/io/github/ggomarighetti/jparsqlsearch/unit/SearchPathTest.java
@@ -9,14 +9,19 @@ import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
-import java.math.BigDecimal;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -24,7 +29,9 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static io.github.ggomarighetti.jparsqlsearch.unit.ExceptionAssertions.thrownBy;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SearchPathTest {
@@ -91,11 +98,35 @@ class SearchPathTest {
                 "concreteLines.sku",
                 String.class,
                 DEEP_PATHS);
+        SearchPath.Metadata nested = SearchPath.metadata(
+                ConcreteForwardingGenericRoot.class,
+                "sku",
+                "concreteLines.sku",
+                String.class,
+                DEEP_PATHS);
+        SearchPath.Metadata interfaceResolved = SearchPath.metadata(
+                InterfaceGenericRoot.class,
+                "sku",
+                "interfaceLines.sku",
+                String.class,
+                DEEP_PATHS);
+        SearchPath.Metadata wildcardConcrete = SearchPath.metadata(
+                ConcreteWildcardGenericRoot.class,
+                "sku",
+                "wildcardConcreteLines.sku",
+                String.class,
+                DEEP_PATHS);
 
         assertEquals(String.class, bounded.type());
         assertTrue(bounded.traversesCollection());
         assertEquals(String.class, concrete.type());
         assertTrue(concrete.traversesCollection());
+        assertEquals(String.class, nested.type());
+        assertTrue(nested.traversesCollection());
+        assertEquals(String.class, interfaceResolved.type());
+        assertTrue(interfaceResolved.traversesCollection());
+        assertEquals(String.class, wildcardConcrete.type());
+        assertTrue(wildcardConcrete.traversesCollection());
     }
 
     @Test
@@ -123,15 +154,18 @@ class SearchPathTest {
 
     @Test
     void rejectsCollectionPathsWhenElementTypeCannotResolveToAPropertyOwner() {
-        thrownBy(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> SearchPath.metadata(GenericRoot.class, "sku", "nestedLines.sku", String.class, DEEP_PATHS));
-        thrownBy(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> SearchPath.metadata(GenericRoot.class, "sku", "arrayLines.sku", String.class, DEEP_PATHS));
-        thrownBy(
+        assertThrows(
                 IllegalArgumentException.class,
                 () -> SearchPath.metadata(GenericRoot.class, "sku", "lineArrays.sku", String.class, DEEP_PATHS));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> SearchPath.metadata(RawIterableRoot.class, "sku", "rawLines.sku", String.class, DEEP_PATHS));
     }
 
     @Test
@@ -207,41 +241,87 @@ class SearchPathTest {
     }
 
     @Test
-    void privateGenericHelpersHandleExoticReflectiveTypes() throws ReflectiveOperationException {
-        Method collectionElementType = SearchPath.class.getDeclaredMethod(
+    void privateGenericHelpersHandleGenericArgumentFallbacks() throws ReflectiveOperationException {
+        Method collectionElementType = privateMethod(
                 "collectionElementType",
                 Class.class,
-                Type.class);
-        collectionElementType.setAccessible(true);
-        Method genericArgumentFromType = SearchPath.class.getDeclaredMethod(
+                Type.class,
+                Map.class);
+        Method genericArgument = privateMethod(
                 "genericArgument",
                 Type.class,
                 Class.class,
-                int.class);
-        genericArgumentFromType.setAccessible(true);
-        Method genericArgumentFromClass = SearchPath.class.getDeclaredMethod(
+                int.class,
+                Map.class);
+        Method genericArgumentClass = privateMethod(
                 "genericArgument",
                 Class.class,
                 Class.class,
-                int.class);
-        genericArgumentFromClass.setAccessible(true);
-        Method classFromType = SearchPath.class.getDeclaredMethod("classFromType", Type.class);
-        classFromType.setAccessible(true);
-        Method rawClass = SearchPath.class.getDeclaredMethod("rawClass", Type.class);
-        rawClass.setAccessible(true);
+                int.class,
+                Map.class);
 
-        assertEquals(String.class, collectionElementType.invoke(null, Object.class, genericArray(String.class)));
-        assertNull(collectionElementType.invoke(null, String.class, String.class));
-        assertEquals(Line.class, genericArgumentFromType.invoke(null, parameterized(LineBag.class), Iterable.class, 0));
-        assertNull(genericArgumentFromType.invoke(null, parameterized(new UnknownType()), Iterable.class, 0));
-        assertNull(genericArgumentFromType.invoke(null, parameterized(String.class), Iterable.class, 0));
-        assertNull(genericArgumentFromClass.invoke(null, null, Iterable.class, 0));
-        assertNull(genericArgumentFromClass.invoke(null, Object.class, Iterable.class, 0));
-        assertEquals(String[].class, classFromType.invoke(null, genericArray(String.class)));
-        assertNull(classFromType.invoke(null, wildcardWithoutUpperBounds()));
-        assertEquals(Line.class, classFromType.invoke(null, GenericRoot.class.getTypeParameters()[0]));
-        assertNull(classFromType.invoke(null, new UnknownType()));
-        assertEquals(List.class, rawClass.invoke(null, parameterized(List.class, String.class)));
+        assertEquals(String.class, collectionElementType.invoke(null, Object.class, genericArray(String.class), Map.of()));
+        assertNull(collectionElementType.invoke(null, String.class, String.class, Map.of()));
+        assertEquals(Line.class, genericArgument.invoke(null, parameterized(LineBag.class), Iterable.class, 0, Map.of()));
+        assertNull(genericArgument.invoke(null, parameterized(new UnknownType(), Line.class), Iterable.class, 0, Map.of()));
+        assertEquals(Object.class, genericArgument.invoke(null, parameterized(List.class), Iterable.class, 0, Map.of()));
+        assertNull(genericArgument.invoke(null, parameterized(String.class, Line.class), Iterable.class, 0, Map.of()));
+        assertNull(genericArgumentClass.invoke(null, Object.class, Iterable.class, 0, Map.of()));
+        assertNull(genericArgumentClass.invoke(null, String.class, Iterable.class, 0, Map.of()));
+        assertNull(genericArgumentClass.invoke(null, NonResolvingInterfaceRoot.class, Iterable.class, 0, Map.of()));
+    }
+
+    @Test
+    void privateGenericHelpersHandleUnresolvedReflectiveTypes() throws ReflectiveOperationException {
+        Method classFromType = privateMethod("classFromType", Type.class, Map.class);
+        Method typeVariables = privateMethod("typeVariables", Class.class, Class.class);
+        Method resolveTypeVariables = privateMethod("resolveTypeVariables", Type.class, Class.class, Map.class);
+        Method recordTypeVariables = privateMethod("recordTypeVariables", Type.class, Class.class, Map.class);
+
+        assertNull(classFromType.invoke(null, new UnknownType(), Map.of()));
+        assertNull(classFromType.invoke(null, genericArray(new UnknownType()), Map.of()));
+        assertNull(classFromType.invoke(null, wildcard(new Type[0], new Type[0]), Map.of()));
+        assertNull(classFromType.invoke(null, new EmptyBoundsVariable(), Map.of()));
+        assertEquals(Map.of(), typeVariables.invoke(null, null, Line.class));
+        assertEquals(Map.of(), typeVariables.invoke(null, Line.class, null));
+        assertEquals(Map.of(), typeVariables.invoke(null, String.class, Line.class));
+        recordTypeVariables.invoke(null, parameterized(GenericBase.class), GenericBase.class, new LinkedHashMap<>());
+        recordTypeVariables.invoke(null, parameterized(Line.class, String.class), Line.class, new LinkedHashMap<>());
+
+        Map<TypeVariable<?>, Type> interfaceMappings = new LinkedHashMap<>();
+        assertFalse((Boolean) resolveTypeVariables.invoke(null, new UnknownType(), Object.class, interfaceMappings));
+        assertTrue((Boolean) resolveTypeVariables.invoke(
+                null,
+                InterfaceGenericRoot.class,
+                GenericLineProvider.class,
+                interfaceMappings));
+        assertEquals(SpecialLine.class, interfaceMappings.get(GenericLineProvider.class.getTypeParameters()[0]));
+    }
+
+    @Test
+    void privateGenericHelpersSubstituteMappedReflectiveTypes() throws ReflectiveOperationException {
+        Method classFromType = privateMethod("classFromType", Type.class, Map.class);
+        Method substituteType = privateMethod("substituteType", Type.class, Map.class);
+        Method rawClass = privateMethod("rawClass", Type.class);
+        TypeVariable<Class<GenericRoot>> variable = GenericRoot.class.getTypeParameters()[0];
+        Map<TypeVariable<?>, Type> stringMapping = Map.of(variable, String.class);
+
+        assertEquals(String[].class, classFromType.invoke(null, genericArray(variable), stringMapping));
+        assertEquals(
+                List[].class,
+                classFromType.invoke(null, genericArray(variable), Map.of(variable, parameterized(List.class, String.class))));
+        assertEquals(String.class, classFromType.invoke(null, wildcard(variable), stringMapping));
+
+        Type substituted = (Type) substituteType.invoke(null, parameterized(List.class, variable), stringMapping);
+        assertEquals(List.class, rawClass.invoke(null, substituted));
+        assertNull(((ParameterizedType) substituted).getOwnerType());
+        assertSame(variable, substituteType.invoke(null, variable, Map.of()));
+        assertSame(variable, substituteType.invoke(null, variable, Map.of(variable, variable)));
+        WildcardType unchangedWildcard = wildcard(String.class);
+        assertSame(unchangedWildcard, substituteType.invoke(null, unchangedWildcard, Map.of()));
+        WildcardType lowerBoundedWildcard = wildcard(new Type[] {Object.class}, new Type[] {variable});
+        WildcardType substitutedWildcard = (WildcardType) substituteType.invoke(null, lowerBoundedWildcard, stringMapping);
+        assertEquals(String.class, substitutedWildcard.getLowerBounds()[0]);
     }
 
     private static void assertCollectionPath(String path) {
@@ -259,12 +339,14 @@ class SearchPathTest {
         assertEquals(toManyPaths, topology.toManyPaths());
     }
 
-    private static GenericArrayType genericArray(Type componentType) {
-        return () -> componentType;
+    private static Method privateMethod(String name, Class<?>... parameterTypes) throws ReflectiveOperationException {
+        Method method = SearchPath.class.getDeclaredMethod(name, parameterTypes);
+        method.setAccessible(true);
+        return method;
     }
 
-    private static ParameterizedType parameterized(Class<?> rawType, Type... arguments) {
-        return parameterized((Type) rawType, arguments);
+    private static GenericArrayType genericArray(Type componentType) {
+        return () -> componentType;
     }
 
     private static ParameterizedType parameterized(Type rawType, Type... arguments) {
@@ -286,21 +368,22 @@ class SearchPathTest {
         };
     }
 
-    private static WildcardType wildcardWithoutUpperBounds() {
+    private static WildcardType wildcard(Type upperBound) {
+        return wildcard(new Type[] {upperBound}, new Type[0]);
+    }
+
+    private static WildcardType wildcard(Type[] upperBounds, Type[] lowerBounds) {
         return new WildcardType() {
             @Override
             public Type[] getUpperBounds() {
-                return new Type[0];
+                return upperBounds;
             }
 
             @Override
             public Type[] getLowerBounds() {
-                return new Type[0];
+                return lowerBounds;
             }
         };
-    }
-
-    private static final class UnknownType implements Type {
     }
 
     private static final class FieldOnlyRoot {
@@ -395,6 +478,53 @@ class SearchPathTest {
         }
     }
 
+    private static final class RawIterableRoot {
+        @SuppressWarnings("rawtypes")
+        public Iterable getRawLines() {
+            return List.of();
+        }
+    }
+
+    private static final class UnknownType implements Type {
+    }
+
+    private static final class EmptyBoundsVariable implements TypeVariable<GenericDeclaration> {
+        @Override
+        public Type[] getBounds() {
+            return new Type[0];
+        }
+
+        @Override
+        public GenericDeclaration getGenericDeclaration() {
+            return GenericRoot.class;
+        }
+
+        @Override
+        public String getName() {
+            return "T";
+        }
+
+        @Override
+        public AnnotatedType[] getAnnotatedBounds() {
+            return new AnnotatedType[0];
+        }
+
+        @Override
+        public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+            return null;
+        }
+
+        @Override
+        public Annotation[] getAnnotations() {
+            return new Annotation[0];
+        }
+
+        @Override
+        public Annotation[] getDeclaredAnnotations() {
+            return new Annotation[0];
+        }
+    }
+
     private static class GenericBase<T extends Line> {
         public List<T> getConcreteLines() {
             return List.of();
@@ -402,6 +532,30 @@ class SearchPathTest {
     }
 
     private static final class ConcreteGenericRoot extends GenericBase<SpecialLine> {
+    }
+
+    private static class ForwardingGenericRoot<T extends Line> extends GenericBase<T> {
+    }
+
+    private static final class ConcreteForwardingGenericRoot extends ForwardingGenericRoot<SpecialLine> {
+    }
+
+    private interface GenericLineProvider<T extends Line> {
+        default List<T> getInterfaceLines() {
+            return List.of();
+        }
+    }
+
+    private static final class InterfaceGenericRoot implements GenericLineProvider<SpecialLine> {
+    }
+
+    private static class WildcardGenericBase<T extends Line> {
+        public List<? extends T> getWildcardConcreteLines() {
+            return List.of();
+        }
+    }
+
+    private static final class ConcreteWildcardGenericRoot extends WildcardGenericBase<SpecialLine> {
     }
 
     private static final class SpecialLine extends Line {
@@ -420,6 +574,13 @@ class SearchPathTest {
         @Override
         public Iterator<Line> iterator() {
             return List.<Line>of().iterator();
+        }
+    }
+
+    private static final class NonResolvingInterfaceRoot implements Runnable {
+        @Override
+        public void run() {
+            // This fixture only needs the declared Runnable interface for traversal.
         }
     }
 


### PR DESCRIPTION
### Resume
- Reject malformed dotted paths consistently across definition, JPA metamodel validation, and criteria sorting.
- Preserve existing `distinct(true)` from application specifications and clarify bounded `unpaged` behavior.
- Make RSQL configuration and extension contracts explicit: compiler auto-configuration now backs off without an engine, custom dialects can be registered, non-Perplexhub argument types are relaxed, dynamic search definitions close correctly, generic path element types resolve, and comparison order is preserved.

### Evidence
> Not required

### Reference
> Not required