### PR TITLE
feat(security): adopt OpenSSF supply-chain controls

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,14 @@
+FROM gcr.io/oss-fuzz-base/base-builder-jvm
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y maven openjdk-17-jdk \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
+COPY . $SRC/jpa-rsql-search
+WORKDIR $SRC/jpa-rsql-search
+
+COPY .clusterfuzzlite/build.sh $SRC/
+COPY .clusterfuzzlite/RsqlSearchFuzzer.java $SRC/

--- a/.clusterfuzzlite/RsqlSearchFuzzer.java
+++ b/.clusterfuzzlite/RsqlSearchFuzzer.java
@@ -1,0 +1,58 @@
+import io.github.ggomarighetti.jparsqlsearch.compile.SearchCompiler;
+import io.github.ggomarighetti.jparsqlsearch.definition.SearchDefinition;
+import io.github.ggomarighetti.jparsqlsearch.policy.SearchPolicy;
+import io.github.ggomarighetti.jparsqlsearch.protection.SearchProtectionException;
+import io.github.ggomarighetti.jparsqlsearch.rsql.backend.perplexhub.PerplexhubRsqlEngines;
+import io.github.ggomarighetti.jparsqlsearch.rsql.validation.RsqlFilterValidationException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.data.domain.PageRequest;
+
+public final class RsqlSearchFuzzer {
+    private static final int MAX_INPUT_BYTES = 16_384;
+    private static final SearchCompiler COMPILER =
+            new SearchCompiler(PerplexhubRsqlEngines.defaults(), SearchPolicy.defaults());
+    private static final PageRequest PAGE_REQUEST = PageRequest.of(0, 20);
+    private static final SearchDefinition<Product> DEFINITION = SearchDefinition.builder()
+            .entity(Product.class)
+            .fields(fields -> {
+                fields.add("sku", String.class).filterable();
+                fields.add("name", String.class).filterable();
+                fields.add("stock", Integer.class).filterable();
+            })
+            .paging()
+            .build();
+
+    private RsqlSearchFuzzer() {
+    }
+
+    public static void fuzzerTestOneInput(byte[] bytes) {
+        if (bytes.length > MAX_INPUT_BYTES) {
+            return;
+        }
+
+        String input = new String(bytes, StandardCharsets.UTF_8);
+        try {
+            COMPILER.compile(input, null, PAGE_REQUEST, DEFINITION);
+        } catch (RsqlFilterValidationException | SearchProtectionException expected) {
+            // Rejected input is a normal outcome. Any other throwable is a finding.
+        }
+    }
+
+    public static final class Product {
+        private String sku;
+        private String name;
+        private Integer stock;
+
+        public String getSku() {
+            return sku;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Integer getStock() {
+            return stock;
+        }
+    }
+}

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$SRC/jpa-rsql-search"
+
+./mvnw -B -ntp -nsu -DskipTests install
+./mvnw -B -ntp -nsu \
+  -pl jpa-rsql-search-perplexhub \
+  -am \
+  dependency:copy-dependencies \
+  -DincludeScope=runtime \
+  -DoutputDirectory="$OUT/dependencies"
+
+find . -path '*/target/*.jar' \
+  ! -name '*-sources.jar' \
+  ! -name '*-javadoc.jar' \
+  ! -name '*-tests.jar' \
+  -exec cp {} "$OUT/dependencies/" \;
+
+build_classpath="$(find "$OUT/dependencies" -name '*.jar' -printf '%p:' | sort)"
+javac -cp "${build_classpath}${JAZZER_API_PATH}" -d "$OUT" "$SRC/RsqlSearchFuzzer.java"
+
+runtime_classpath='${this_dir}'
+while IFS= read -r jar; do
+  runtime_classpath="${runtime_classpath}:\${this_dir}/dependencies/$(basename "$jar")"
+done < <(find "$OUT/dependencies" -name '*.jar' | sort)
+
+cat > "$OUT/RsqlSearchFuzzer" <<EOF
+#!/usr/bin/env bash
+# LLVMFuzzerTestOneInput for fuzzer detection.
+this_dir=\$(dirname "\$0")
+LD_LIBRARY_PATH="${JVM_LD_LIBRARY_PATH}:\${this_dir}" \
+\${this_dir}/jazzer_driver \
+  --agent_path=\${this_dir}/jazzer_agent_deploy.jar \
+  --cp="${runtime_classpath}" \
+  --target_class=RsqlSearchFuzzer \
+  --jvm_args="-Xmx2048m:-Djava.awt.headless=true" \
+  "\$@"
+EOF
+chmod +x "$OUT/RsqlSearchFuzzer"

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,6 @@
+language: jvm
+fuzzing_engines:
+  - libfuzzer
+sanitizers:
+  - address
+main_repo: https://github.com/ggomarighetti/jpa-rsql-search

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.idea
+target
+**/target
+*.iml

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+* @ggomarighetti
+
+/.github/ @ggomarighetti
+/SECURITY.md @ggomarighetti
+/docs/ @ggomarighetti
+/pom.xml @ggomarighetti
+/jreleaser.yml @ggomarighetti

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Report a reproducible defect.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not report security vulnerabilities here. Use private vulnerability
+        reporting from SECURITY.md.
+  - type: input
+    id: version
+    attributes:
+      label: Version and module
+      placeholder: "2.0.0, jpa-rsql-search-core"
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Java, Spring Boot, Spring Data JPA, Hibernate, and database versions.
+    validations:
+      required: true
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: Provide code or a repository without private data or credentials.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/ggomarighetti/jpa-rsql-search/security/advisories/new
+    about: Report suspected vulnerabilities privately.
+  - name: Usage question
+    url: https://github.com/ggomarighetti/jpa-rsql-search/discussions
+    about: Ask for help or discuss designs.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Propose a focused enhancement.
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user or integration problem should be solved?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+    validations:
+      required: true
+  - type: textarea
+    id: security
+    attributes:
+      label: Security and compatibility impact
+      description: Describe trust-boundary, API, dependency, and migration effects.
+    validations:
+      required: true

--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -1,0 +1,51 @@
+name: ClusterFuzzLite
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "11 2 * * 6"
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: Fuzz RSQL compiler
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Build fuzzers
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: jvm
+          sanitizer: address
+          github-token: ${{ github.token }}
+
+      - name: Run fuzzers
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: jvm
+          sanitizer: address
+          mode: ${{ github.event_name == 'schedule' && 'batch' || 'code-change' }}
+          fuzz-seconds: ${{ github.event_name == 'schedule' && '900' || '120' }}
+          github-token: ${{ github.token }}
+          output-sarif: true
+          parallel-fuzzing: true

--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -11,7 +11,8 @@ on:
     - cron: "11 2 * * 6"
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,68 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "41 3 * * 4"
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: java-kotlin
+            build-mode: manual
+          - language: javascript-typescript
+            build-mode: none
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 25
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Build
+        if: matrix.build-mode == 'manual'
+        run: ./mvnw -B -ntp -nsu -DskipTests package
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,8 @@ on:
     - cron: "41 3 * * 4"
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -8,13 +8,14 @@ on:
       - reopened
       - synchronize
 
-permissions:
-  pull-requests: read
+permissions: read-all
 
 jobs:
   title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Validate title
         env:

--- a/.github/workflows/conventional-pr.yml
+++ b/.github/workflows/conventional-pr.yml
@@ -8,7 +8,8 @@ on:
       - reopened
       - synchronize
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   title:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -9,7 +9,8 @@ on:
       - reopened
       - synchronize
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   dco:

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,43 @@
+name: Developer Certificate of Origin
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions: read-all
+
+jobs:
+  dco:
+    name: Check commit sign-offs
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Verify Signed-off-by trailers
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PULL_REQUEST: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing="$(gh api --paginate \
+            "repos/${REPOSITORY}/pulls/${PULL_REQUEST}/commits" \
+            --jq '.[] | select(.commit.message | test("(?m)^Signed-off-by: .+ <[^>]+>$") | not) | "\(.sha[0:12]) \(.commit.author.name)"')"
+
+          if [[ -n "${missing}" ]]; then
+            echo "::error::Every human-authored commit must include a Signed-off-by trailer."
+            echo "${missing}"
+            echo "Use: git commit --amend --signoff"
+            exit 1
+          fi

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - master
+
+permissions: read-all
+
+jobs:
+  dependency-review:
+    name: Review dependency changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Review dependencies
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          deny-licenses: AGPL-1.0-only, AGPL-1.0-or-later, SSPL-1.0
+          comment-summary-in-pr: never

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - master
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   dependency-review:

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -11,7 +11,8 @@ on:
     - cron: "23 5 * * 3"
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,64 @@
+name: OSV-Scanner
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "23 5 * * 3"
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-sbom:
+    name: Build CycloneDX SBOM
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 25
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Generate SBOM
+        run: ./mvnw -B -ntp -nsu -Psbom -DskipTests package
+
+      - name: Upload aggregate SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cyclonedx-sbom
+          path: target/bom.json
+          if-no-files-found: error
+          retention-days: 5
+
+  scan:
+    name: Scan SBOM
+    needs: build-sbom
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      download-artifact: cyclonedx-sbom
+      scan-args: --sbom=./bom.json
+      fail-on-vuln: true
+      upload-sarif: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,10 +6,7 @@ on:
       - master
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: read-all
 
 concurrency:
   group: release-please-${{ github.ref }}
@@ -19,6 +16,10 @@ jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Check bootstrap release tag
         id: bootstrap
@@ -35,7 +36,7 @@ jobs:
 
       - name: Release Please
         if: steps.bootstrap.outputs.ready == 'true'
-        uses: googleapis/release-please-action@8b8fd2cc23b2e18957157a9d923d75aa0c6f6ad5
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,7 +6,8 @@ on:
       - master
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: release-please-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,7 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
-  packages: write
+permissions: read-all
 
 concurrency:
   group: release-${{ github.ref }}
@@ -43,6 +41,11 @@ jobs:
     name: Release Maven Central
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
+      packages: write
     env:
       CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
       CENTRAL_PORTAL_PASSWORD: ${{ secrets.CENTRAL_PORTAL_PASSWORD }}
@@ -60,12 +63,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Java 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: temurin
           java-version: "25"
@@ -151,13 +155,13 @@ jobs:
 
       - name: Verify release build
         if: steps.release.outputs.release == 'true'
-        run: ./mvnw $MAVEN_ARGS -Pcoverage,release verify
+        run: ./mvnw $MAVEN_ARGS -Pcoverage,release,sbom,reproducible verify
 
       - name: Stage Maven artifacts
         if: steps.release.outputs.release == 'true'
         run: |
           rm -rf target/staging-deploy
-          ./mvnw $MAVEN_ARGS -Ppublication -DskipTests deploy
+          ./mvnw $MAVEN_ARGS -Ppublication,sbom,reproducible -DskipTests deploy
 
       - name: Inspect staged artifacts
         if: steps.release.outputs.release == 'true'
@@ -184,11 +188,58 @@ jobs:
             test -f "${artifact_dir}/${artifact}-${version}.jar"
             test -f "${artifact_dir}/${artifact}-${version}-sources.jar"
             test -f "${artifact_dir}/${artifact}-${version}-javadoc.jar"
+            test -f "${artifact_dir}/${artifact}-${version}-cyclonedx.json"
           done
 
           test ! -e "${group_dir}/jpa-rsql-search/${version}"
           test ! -e "${group_dir}/jpa-rsql-search-integration-tests/${version}"
           find "${group_dir}" -type f | sort
+
+      - name: Prepare release evidence
+        if: steps.release.outputs.release == 'true'
+        id: evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${{ steps.release.outputs.version }}"
+          mkdir -p release-assets
+          cp target/bom.json "release-assets/jpa-rsql-search-${version}-aggregate-cyclonedx.json"
+          cp "target/jpa-rsql-search-parent-${version}.buildinfo" \
+            "release-assets/jpa-rsql-search-${version}.buildinfo"
+
+          find target/staging-deploy -type f -print0 \
+            | sort -z \
+            | xargs -0 sha256sum \
+            > "release-assets/jpa-rsql-search-${version}-SHA256SUMS"
+
+      - name: Attest release provenance
+        if: steps.release.outputs.release == 'true' && env.DRY_RUN != 'true'
+        id: provenance
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-checksums: release-assets/jpa-rsql-search-${{ steps.release.outputs.version }}-SHA256SUMS
+          create-storage-record: false
+
+      - name: Attest aggregate SBOM
+        if: steps.release.outputs.release == 'true' && env.DRY_RUN != 'true'
+        id: sbom-attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-checksums: release-assets/jpa-rsql-search-${{ steps.release.outputs.version }}-SHA256SUMS
+          sbom-path: release-assets/jpa-rsql-search-${{ steps.release.outputs.version }}-aggregate-cyclonedx.json
+          create-storage-record: false
+
+      - name: Collect Sigstore bundles
+        if: steps.release.outputs.release == 'true' && env.DRY_RUN != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.release.outputs.version }}"
+          cp "${{ steps.provenance.outputs.bundle-path }}" \
+            "release-assets/jpa-rsql-search-${version}-provenance.sigstore.json"
+          cp "${{ steps.sbom-attestation.outputs.bundle-path }}" \
+            "release-assets/jpa-rsql-search-${version}-sbom.sigstore.json"
 
       - name: Validate JReleaser configuration
         if: steps.release.outputs.release == 'true'
@@ -200,6 +251,8 @@ jobs:
 
       - name: Create signed tag
         if: steps.release.outputs.release == 'true' && env.DRY_RUN != 'true' && steps.release.outputs.tag_exists != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -228,6 +281,7 @@ jobs:
           tag="${{ steps.release.outputs.tag }}"
           git tag -s "${tag}" -m "jpa-rsql-search ${tag}"
           git tag -v "${tag}"
+          gh auth setup-git
           git push origin "${tag}"
 
       - name: Publish to GitHub Packages
@@ -273,9 +327,12 @@ jobs:
           else
             gh release create "${tag}" --title "${title}" --notes-file release-notes.md --latest
           fi
+          gh release upload "${tag}" release-assets/* --clobber
 
       - name: Create version branch
         if: steps.release.outputs.release == 'true' && env.DRY_RUN != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -296,7 +353,10 @@ jobs:
             exit 0
           fi
 
-          git push origin "${tag_commit}:${branch_ref}"
+          gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+            --method POST \
+            --field ref="${branch_ref}" \
+            --field sha="${tag_commit}"
 
       - name: Release summary
         if: steps.release.outputs.release == 'true'
@@ -310,6 +370,9 @@ jobs:
             echo "- Dry run: ${DRY_RUN}"
             echo "- Existing tag: ${{ steps.release.outputs.tag_exists }}"
             echo "- Parent plus public modules: staged atomically"
+            echo "- CycloneDX SBOMs: attached to Maven artifacts"
+            echo "- Provenance and SBOM attestations: signed with Sigstore"
+            echo "- SHA-256 manifest and buildinfo: attached to the GitHub release"
             echo "- Retired jpa-rsql-search artifact: not generated"
             echo "- Maven Central: published when dry run is false"
             echo "- GitHub Packages: published when dry run is false"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,8 @@ on:
         type: boolean
         default: false
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,6 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  MAVEN_ARGS: -B -ntp -nsu
-
 jobs:
   release:
     name: Release Maven Central
@@ -91,8 +88,10 @@ jobs:
           fi
 
           if [[ "${version}" == *-SNAPSHOT ]]; then
-            echo "release=false" >> "$GITHUB_OUTPUT"
-            echo "version=${version}" >> "$GITHUB_OUTPUT"
+            {
+              echo "release=false"
+              echo "version=${version}"
+            } >> "$GITHUB_OUTPUT"
             echo "::notice::pom.xml is at ${version}; skipping release publication."
             exit 0
           fi
@@ -104,9 +103,11 @@ jobs:
           fi
 
           if [[ "${tag_exists}" == "true" && "${ALLOW_EXISTING_TAG}" != "true" ]]; then
-            echo "release=false" >> "$GITHUB_OUTPUT"
-            echo "version=${version}" >> "$GITHUB_OUTPUT"
-            echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+            {
+              echo "release=false"
+              echo "version=${version}"
+              echo "tag=${tag}"
+            } >> "$GITHUB_OUTPUT"
             echo "::notice::${tag} already exists; skipping publication."
             exit 0
           fi
@@ -121,10 +122,12 @@ jobs:
             fi
           fi
 
-          echo "release=true" >> "$GITHUB_OUTPUT"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "tag_exists=${tag_exists}" >> "$GITHUB_OUTPUT"
+          {
+            echo "release=true"
+            echo "version=${version}"
+            echo "tag=${tag}"
+            echo "tag_exists=${tag_exists}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Validate release metadata
         if: steps.release.outputs.release == 'true'
@@ -155,13 +158,13 @@ jobs:
 
       - name: Verify release build
         if: steps.release.outputs.release == 'true'
-        run: ./mvnw $MAVEN_ARGS -Pcoverage,release,sbom,reproducible verify
+        run: ./mvnw -B -ntp -nsu -Pcoverage,release,sbom,reproducible verify
 
       - name: Stage Maven artifacts
         if: steps.release.outputs.release == 'true'
         run: |
           rm -rf target/staging-deploy
-          ./mvnw $MAVEN_ARGS -Ppublication,sbom,reproducible -DskipTests deploy
+          ./mvnw -B -ntp -nsu -Ppublication,sbom,reproducible -DskipTests deploy
 
       - name: Inspect staged artifacts
         if: steps.release.outputs.release == 'true'
@@ -243,11 +246,11 @@ jobs:
 
       - name: Validate JReleaser configuration
         if: steps.release.outputs.release == 'true'
-        run: ./mvnw $MAVEN_ARGS -N jreleaser:config
+        run: ./mvnw -B -ntp -nsu -N jreleaser:config
 
       - name: JReleaser dry-run
         if: steps.release.outputs.release == 'true'
-        run: ./mvnw $MAVEN_ARGS -N jreleaser:deploy -Djreleaser.dry.run=true
+        run: ./mvnw -B -ntp -nsu -N jreleaser:deploy -Djreleaser.dry.run=true
 
       - name: Create signed tag
         if: steps.release.outputs.release == 'true' && env.DRY_RUN != 'true' && steps.release.outputs.tag_exists != 'true'
@@ -286,14 +289,14 @@ jobs:
 
       - name: Publish to GitHub Packages
         if: steps.release.outputs.release == 'true' && env.DRY_RUN != 'true'
-        run: ./mvnw $MAVEN_ARGS -Ppublication -DskipTests "-DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}" deploy
+        run: ./mvnw -B -ntp -nsu -Ppublication -DskipTests "-DaltDeploymentRepository=github::default::https://maven.pkg.github.com/${{ github.repository }}" deploy
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Publish to Maven Central
         if: steps.release.outputs.release == 'true' && env.DRY_RUN != 'true'
-        run: ./mvnw $MAVEN_ARGS -N jreleaser:deploy
+        run: ./mvnw -B -ntp -nsu -N jreleaser:deploy
 
       - name: Extract release notes
         if: steps.release.outputs.release == 'true' && env.DRY_RUN != 'true'

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -1,0 +1,32 @@
+name: Reproducible Build
+
+on:
+  schedule:
+    - cron: "7 1 * * 1"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  verify:
+    name: Compare independent builds
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 25
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Verify reproducible artifacts
+        run: ./scripts/verify-reproducible-build.sh

--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -5,7 +5,8 @@ on:
     - cron: "7 1 * * 1"
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   verify:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,7 +9,8 @@ on:
     - cron: "17 4 * * 2"
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,54 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "17 4 * * 2"
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Analyze supply-chain security
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload Scorecard artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: scorecard-results.sarif
+          retention-days: 5
+          if-no-files-found: error
+
+      - name: Upload Scorecard results to code scanning
+        if: ${{ always() }}
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: scorecard-results.sarif

--- a/.github/workflows/security-metadata.yml
+++ b/.github/workflows/security-metadata.yml
@@ -9,7 +9,8 @@ on:
       - master
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   security-insights:
@@ -34,6 +35,8 @@ jobs:
           set -euo pipefail
           schema="${RUNNER_TEMP}/security-insights-schema.cue"
           curl --fail --silent --show-error --location \
+            --proto '=https' \
+            --proto-redir '=https' \
             "https://raw.githubusercontent.com/ossf/security-insights/701ac2a02ef17fc8b316f5df685428773c51372a/spec/schema.cue" \
             --output "${schema}"
           cue vet -d '#SecurityInsights' "${schema}" security-insights.yml

--- a/.github/workflows/security-metadata.yml
+++ b/.github/workflows/security-metadata.yml
@@ -1,0 +1,61 @@
+name: Security Metadata
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  security-insights:
+    name: Validate Security Insights
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up CUE
+        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+
+      - name: Validate document
+        shell: bash
+        run: |
+          set -euo pipefail
+          schema="${RUNNER_TEMP}/security-insights-schema.cue"
+          curl --fail --silent --show-error --location \
+            "https://raw.githubusercontent.com/ossf/security-insights/701ac2a02ef17fc8b316f5df685428773c51372a/spec/schema.cue" \
+            --output "${schema}"
+          cue vet -d '#SecurityInsights' "${schema}" security-insights.yml
+
+  actionlint:
+    name: Validate GitHub Actions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        shell: bash
+        run: |
+          docker run --rm \
+            --volume "${PWD}:/repo" \
+            --workdir /repo \
+            rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
+            -color

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,8 +11,7 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
-permissions:
-  contents: read
+permissions: read-all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
@@ -35,12 +34,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Java 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: temurin
           java-version: "25"
@@ -48,18 +48,20 @@ jobs:
 
       - name: Verify
         if: github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
-        run: ./mvnw $MAVEN_ARGS -Pcoverage verify
+        run: ./mvnw $MAVEN_ARGS -Pcoverage,sbom verify
 
       - name: Verify release profile
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
-        run: ./mvnw $MAVEN_ARGS -Pcoverage,release verify
+        run: ./mvnw $MAVEN_ARGS -Pcoverage,release,sbom,reproducible verify
 
       - name: Upload test and coverage artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-and-coverage-reports
           path: |
+            target/bom.json
+            jpa-rsql-search-*/target/bom.json
             jpa-rsql-search-*/target/site/jacoco/
             integration-tests/target/site/jacoco-aggregate/
             jpa-rsql-search-*/target/surefire-reports/
@@ -128,10 +130,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Java ${{ matrix.java }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -11,7 +11,8 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,9 +17,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  MAVEN_ARGS: -B -ntp -nsu
-
 jobs:
   verify:
     name: Verify (Java 25)
@@ -48,11 +45,11 @@ jobs:
 
       - name: Verify
         if: github.event_name != 'workflow_dispatch' && github.event_name != 'schedule'
-        run: ./mvnw $MAVEN_ARGS -Pcoverage,sbom verify
+        run: ./mvnw -B -ntp -nsu -Pcoverage,sbom verify
 
       - name: Verify release profile
         if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
-        run: ./mvnw $MAVEN_ARGS -Pcoverage,release,sbom,reproducible verify
+        run: ./mvnw -B -ntp -nsu -Pcoverage,release,sbom,reproducible verify
 
       - name: Upload test and coverage artifacts
         if: ${{ always() }}
@@ -113,7 +110,7 @@ jobs:
 
       - name: SonarQube Cloud analysis
         if: ${{ env.SONAR_TOKEN != '' }}
-        run: ./mvnw $MAVEN_ARGS sonar:sonar
+        run: ./mvnw -B -ntp -nsu sonar:sonar
 
       - name: Skip SonarQube Cloud analysis
         if: ${{ env.SONAR_TOKEN == '' }}
@@ -142,4 +139,4 @@ jobs:
           cache: maven
 
       - name: Test
-        run: ./mvnw $MAVEN_ARGS test
+        run: ./mvnw -B -ntp -nsu test

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our commitment
+
+Project spaces must be welcoming, respectful, and safe for people regardless
+of experience, identity, background, or affiliation.
+
+## Expected behavior
+
+- Be constructive and technically specific.
+- Assume good faith while remaining open to correction.
+- Respect boundaries and differing levels of experience.
+- Focus criticism on ideas and code, not people.
+- Protect private information and coordinated vulnerability reports.
+- Accept maintainer decisions about scope without harassment.
+
+## Unacceptable behavior
+
+Harassment, threats, discrimination, sexualized attention, deliberate
+intimidation, doxxing, repeated disruption, and bad-faith security disclosures
+are not tolerated.
+
+## Enforcement
+
+Report conduct concerns privately through:
+
+https://github.com/ggomarighetti/jpa-rsql-search/security/advisories/new
+
+The maintainer may remove content, restrict participation, or ban contributors
+when necessary. Reports are handled confidentially to the extent practical.
+Good-faith disagreement, technical criticism, and responsible security
+research are not violations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing
+
+Issues, documentation improvements, tests, and code changes are welcome.
+
+## Before opening a change
+
+- Use an issue or discussion for large API or architecture changes.
+- Keep pull requests focused and explain user-visible behavior.
+- Do not report vulnerabilities publicly; follow [SECURITY.md](SECURITY.md).
+- Avoid committing generated artifacts, credentials, or local configuration.
+
+## Developer setup
+
+Requirements:
+
+- JDK 17 or newer;
+- Docker for PostgreSQL integration tests;
+- Git.
+
+Run the full verification suite:
+
+```bash
+./mvnw verify
+```
+
+Run coverage and release checks:
+
+```bash
+./mvnw -Pcoverage,release verify
+```
+
+Generate and validate release SBOMs:
+
+```bash
+./mvnw -Psbom package
+```
+
+## Change requirements
+
+- Follow the existing Java style: four-space indentation, braces on the same
+  line, explicit imports, and no wildcard imports.
+- Preserve Java 17 compatibility.
+- Add or update automated tests for new behavior and bug fixes.
+- Major functionality must include tests for its public behavior, boundary
+  cases, and failure paths.
+- Public API changes require Javadocs and migration notes.
+- Dependency changes must pass dependency review and vulnerability scanning.
+- Do not weaken validation, protection limits, CI permissions, or release
+  integrity without an explicit security rationale.
+
+Pull request titles follow Conventional Commits, for example:
+
+```text
+feat(core): add bounded operator support
+fix(parser): reject malformed selector escapes
+docs(security): clarify vulnerability reporting
+```
+
+## Developer Certificate of Origin
+
+Every commit must include a `Signed-off-by` trailer certifying the
+[Developer Certificate of Origin 1.1](https://developercertificate.org/).
+
+Create signed-off commits with:
+
+```bash
+git commit --signoff
+```
+
+The sign-off means you have the legal right to submit the contribution under
+the project's license. It is not a cryptographic signature.
+
+## Review
+
+Automated checks must pass before merge. Human review by a non-author is
+required when the project has a second active maintainer. Until then, the sole
+maintainer documents this limitation and does not use alternate accounts or
+rubber-stamp reviews to manufacture compliance.
+
+Maintainers review correctness, compatibility, tests, security impact,
+dependency changes, documentation, and release implications.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,54 @@
+# Governance
+
+`jpa-rsql-search` is currently a maintainer-led project.
+
+## Roles
+
+### Maintainer
+
+Maintainers may triage issues, review changes, manage repository settings,
+publish releases, respond to vulnerability reports, and appoint additional
+maintainers.
+
+Maintainers must:
+
+- use multi-factor authentication;
+- follow least privilege;
+- protect release and signing credentials;
+- disclose conflicts of interest;
+- document security-relevant exceptions;
+- avoid unilateral changes that bypass required checks.
+
+### Contributor
+
+Contributors propose changes through issues, discussions, and pull requests.
+Contributions require DCO sign-off and are reviewed under
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Decisions
+
+Routine decisions are made through reviewed pull requests. Significant API,
+security, release, or governance changes should have a public issue or
+discussion before implementation.
+
+When more than one maintainer is active, decisions seek consensus. If consensus
+cannot be reached, the maintainer responsible for the affected area decides and
+records the rationale publicly.
+
+## Maintainer access
+
+Elevated access is granted only after sustained, constructive contributions and
+a review of the candidate's need, security practices, and ability to maintain
+the project. Permissions start at the lowest practical level.
+
+The current access list is maintained in [MAINTAINERS.md](MAINTAINERS.md).
+
+## Continuity
+
+The project currently has a bus factor of one. This is a documented limitation,
+not a target state. The project will seek a second maintainer before claiming
+OpenSSF maturity levels that require independent review or continuity.
+
+Repository history, build instructions, release automation, policy, and
+security response procedures are kept in the public repository to reduce
+handover risk.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,13 @@
+# Maintainers
+
+## Project maintainer and administrator
+
+- [@ggomarighetti](https://github.com/ggomarighetti) — project administration,
+  code review, release management, Maven Central publishing, and vulnerability
+  response.
+
+This is also the complete current list of people with access to sensitive
+project resources.
+
+Security reports must use the private process in [SECURITY.md](SECURITY.md);
+they should not be sent through public profile contact details.

--- a/OPENSSF_SECURITY_ADOPTION_PLAN.md
+++ b/OPENSSF_SECURITY_ADOPTION_PLAN.md
@@ -1,0 +1,217 @@
+# OpenSSF: investigación, auditoría y plan de adopción
+
+Fecha de evaluación: 2026-06-21
+
+Repositorio: `ggomarighetti/jpa-rsql-search`
+
+Rama de implementación: `codex/openssf-hardening`
+
+Base: `origin/master` en `207bd2e2307aba2b1d70f67169017f4bf888c97e`
+
+## Resumen ejecutivo
+
+OpenSSF no es un único paquete que se instala. Es un ecosistema de estándares,
+evaluaciones y herramientas para seguridad de proyectos open source. Para este
+repositorio se adoptan cuatro capas complementarias:
+
+1. OpenSSF OSPS Baseline 2026.02.19 como catálogo de controles.
+2. OpenSSF Scorecard como evaluación automatizada continua.
+3. OpenSSF Best Practices como autoevaluación pública manual.
+4. SBOM, firmas, attestations y builds reproducibles para la cadena de
+   suministro.
+
+El código ya partía de una base fuerte: Maven multi-módulo, Java 17+, CI en
+Java 17/21/25, Dependabot, CodeQL, SonarQube, Testcontainers, tags GPG y
+publicación automatizada. Las brechas principales estaban en documentación,
+gobernanza, permisos de Actions, dependencias de workflows sin pin, SBOM,
+provenance, reproducibilidad y fuzzing coverage-guided.
+
+## Alcance investigado
+
+- OSPS Baseline 2026.02.19 y sus 64 requisitos.
+- OpenSSF Scorecard y sus checks vigentes.
+- OpenSSF Best Practices Passing, Silver y Gold.
+- Security Insights 2.2.0.
+- SLSA 1.2, GitHub artifact attestations y Sigstore.
+- CycloneDX Maven Plugin, OSV-Scanner y GitHub Dependency Review.
+- Jazzer y ClusterFuzzLite para JVM.
+- Configuración remota de Actions, rulesets y seguridad de GitHub.
+- POMs, workflows, JReleaser, tests y artefactos del reactor.
+
+## Diagnóstico inicial
+
+| Área | Estado inicial | Riesgo |
+| --- | --- | --- |
+| Política de seguridad | Sin `SECURITY.md` | Reportes públicos o sin SLA |
+| Gobernanza | Sin roles, maintainers ni continuidad | Bus factor 1 no documentado |
+| Contribución | Sin guía, DCO ni templates | Cambios inconsistentes |
+| Actions | Tags móviles y token write por defecto | Compromiso de supply chain |
+| SCA | Dependabot sin gate de PR secundario | Vulnerabilidades introducidas |
+| Release | Sin SBOM, checksums ni provenance pública | Artefacto no trazable |
+| Reproducibilidad | No medida | Build no verificable |
+| Fuzzing | Property tests sin coverage guidance | Casos límite no explorados |
+| Licencia en JAR | Ausente | Distribución incompleta |
+
+El Scorecard público observado sobre `master` era 4,9/10. Parte de los
+resultados eran falsos negativos, pero confirmó brechas reales en
+`Security-Policy`, `Pinned-Dependencies`, `Token-Permissions`,
+`Signed-Releases`, `Fuzzing`, `CII-Best-Practices` y revisión humana.
+
+## Estrategia por control
+
+### OSPS nivel 1
+
+Objetivo: cumplir todos los controles aplicables.
+
+- Fuente e historial públicos: ya cumplido.
+- Licencia OSI y metadata Maven: ya cumplido.
+- Licencia dentro de artefactos: implementado como `META-INF/LICENSE`.
+- Proceso de contribución y soporte: implementado.
+- Reporte privado de vulnerabilidades: documentado.
+- Protección de rama y CI: ya existían; se endurecen.
+- Secret scanning y push protection: ya habilitados.
+
+### OSPS nivel 2 y 3
+
+Se implementan los controles técnicos razonables, pero no se declara
+cumplimiento organizativo total mientras exista un solo maintainer.
+
+- Roles, acceso sensible y escalamiento: documentados.
+- Arquitectura y threat model: documentados.
+- Política de dependencias, licencias, SAST, SCA y secretos: documentada.
+- DCO: automatizado.
+- SBOM y release attestations: implementados.
+- Reproducibilidad: implementada y verificada con dos builds.
+- Revisión no autora: diferida hasta contar con un segundo maintainer real.
+- VEX: se producirá cuando exista un finding no explotable que deba acompañar
+  una release; generar VEX vacío no aporta evidencia.
+
+## Cambios implementados
+
+### Políticas y metadata
+
+- `SECURITY.md`, `SUPPORT.md`, `CONTRIBUTING.md`.
+- `CODE_OF_CONDUCT.md`, `GOVERNANCE.md`, `MAINTAINERS.md`.
+- `docs/ARCHITECTURE.md`, `docs/THREAT_MODEL.md`.
+- `docs/DEPENDENCY_POLICY.md`, `docs/SECRETS_POLICY.md`.
+- `docs/RELEASE_SECURITY.md`, `docs/OPENSSF.md`.
+- `security-insights.yml` conforme al esquema oficial 2.2.0.
+- `CODEOWNERS` e issue forms.
+
+### GitHub Actions
+
+- Todas las Actions fijadas a SHA completa.
+- Permisos read-only por defecto a nivel workflow.
+- Escritura limitada al job que realmente publica o reporta.
+- Checkout sin credenciales persistentes salvo autenticación explícita de
+  publicación.
+- OpenSSF Scorecard con publicación y SARIF.
+- CodeQL explícito para Java.
+- Dependency Review con bloqueo de vulnerabilidades high/critical y licencias
+  copyleft de red restringida.
+- OSV-Scanner sobre el SBOM agregado.
+- DCO para commits humanos.
+- Validación CUE de Security Insights.
+- `actionlint` desde una imagen fijada por digest.
+- Build reproducible semanal.
+
+### Build y release
+
+- Maven Enforcer exige JDK 17+ y Maven 3.9+.
+- `project.build.outputTimestamp` determinista.
+- `META-INF/LICENSE` en los JAR binarios.
+- CycloneDX 1.6 agregado y por módulo publicable.
+- `integration-tests` excluido del SBOM y del despliegue.
+- `maven-artifact-plugin` valida el build plan y genera `.buildinfo`.
+- El release genera SHA-256, provenance Sigstore y SBOM attestation.
+- Los bundles, checksums, SBOM agregado y `.buildinfo` se adjuntan a GitHub
+  Releases.
+- Se conservan las firmas PGP requeridas por Maven Central.
+
+### Fuzzing
+
+- Jazzer JUnit ejecuta el invariante de entrada RSQL arbitraria.
+- ClusterFuzzLite construye un target JVM sobre la API pública y el backend
+  Perplexhub.
+- PR/push: fuzzing corto.
+- Schedule: fuzzing batch prolongado.
+- Los crashes deben convertirse en entradas permanentes del corpus.
+
+## Validaciones ejecutadas
+
+- Tests Maven del core y dependencias: aprobados.
+- Generación CycloneDX y `.buildinfo`: aprobada.
+- Security Insights contra CUE 2.2.0: aprobado.
+- Todos los workflows con actionlint 1.7.12: aprobados.
+- Build ClusterFuzzLite en la imagen oficial: aprobado.
+- Target ClusterFuzzLite/Jazzer: 100 ejecuciones sin crash.
+- Dos builds limpios con comparación SHA-256: bit-for-bit idénticos.
+- JAR inspeccionado con `META-INF/LICENSE`.
+
+## Configuración remota propuesta
+
+Aplicar inmediatamente:
+
+- `default_workflow_permissions=read`.
+- impedir que Actions apruebe pull requests.
+- mantener bloqueo de force-push, borrado, historial lineal y PR obligatorio.
+- exigir que la rama esté actualizada antes del merge.
+
+Aplicar después de que estos workflows existan en `master`:
+
+- exigir pin SHA desde la configuración de Actions;
+- restringir Actions a GitHub, OpenSSF, Google, CUE y la allowlist usada;
+- agregar como required checks Dependency Review, CodeQL, DCO, Security
+  Metadata y los checks de verificación existentes;
+- activar merge protection de code scanning para findings high/critical.
+
+No aplicar todavía:
+
+- una aprobación humana obligatoria;
+- CODEOWNERS review obligatorio;
+- aprobación del último push por otra persona.
+
+Esos controles bloquearían legítimamente a un proyecto de un solo maintainer.
+Se activarán al incorporar un segundo maintainer con responsabilidad real.
+
+## OpenSSF Best Practices
+
+El repositorio queda preparado para completar el cuestionario Passing. La
+creación del registro requiere autenticación del propietario mediante GitHub y
+declaraciones humanas; no debe automatizarse ni responderse ficticiamente.
+
+Silver y Gold quedan como objetivos de madurez. Los bloqueos reales son el bus
+factor, revisión independiente y comunidad, no una carencia técnica que pueda
+resolverse con otro YAML.
+
+## Definition of Done
+
+- [x] Políticas de seguridad, soporte, gobernanza y contribución.
+- [x] Security Insights validado.
+- [x] Actions fijadas a SHA y mínimo privilegio.
+- [x] Scorecard, CodeQL, Dependency Review, OSV y DCO.
+- [x] SBOM por módulo y agregado.
+- [x] Checksums, provenance y SBOM attestations en release.
+- [x] Build reproducible medido.
+- [x] Licencia dentro de los artefactos.
+- [x] Jazzer y ClusterFuzzLite.
+- [x] Documentación de verificación.
+- [ ] OpenSSF Best Practices Passing, pendiente de declaración humana.
+- [ ] Revisión no autora, pendiente de un segundo maintainer.
+- [ ] Hacer obligatorios los nuevos checks después de observar sus nombres en
+      el primer PR.
+
+## Fuentes primarias
+
+- [OpenSSF](https://openssf.org/)
+- [OSPS Baseline 2026.02.19](https://baseline.openssf.org/versions/2026-02-19.html)
+- [OpenSSF Scorecard](https://github.com/ossf/scorecard)
+- [Scorecard Action](https://github.com/ossf/scorecard-action)
+- [Best Practices](https://www.bestpractices.dev/)
+- [Security Insights](https://github.com/ossf/security-insights)
+- [SLSA 1.2](https://slsa.dev/spec/v1.2/)
+- [GitHub artifact attestations](https://docs.github.com/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds)
+- [CycloneDX Maven Plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin)
+- [OSV-Scanner](https://google.github.io/osv-scanner/)
+- [ClusterFuzzLite JVM](https://google.github.io/clusterfuzzlite/build-integration/jvm-lang/)
+- [Maven reproducible builds](https://maven.apache.org/guides/mini/guide-reproducible-builds.html)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # jpa-rsql-search
 
 [![Verify](https://github.com/ggomarighetti/jpa-rsql-search/actions/workflows/verify.yml/badge.svg)](https://github.com/ggomarighetti/jpa-rsql-search/actions/workflows/verify.yml)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.ggomarighetti/jpa-rsql-search.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.ggomarighetti/jpa-rsql-search)
-[![Javadocs](https://javadoc.io/badge2/io.github.ggomarighetti/jpa-rsql-search/javadoc.svg)](https://javadoc.io/doc/io.github.ggomarighetti/jpa-rsql-search)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.ggomarighetti/jpa-rsql-search-spring-boot-starter.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.ggomarighetti/jpa-rsql-search-spring-boot-starter)
+[![Javadocs](https://javadoc.io/badge2/io.github.ggomarighetti/jpa-rsql-search-api/javadoc.svg)](https://javadoc.io/doc/io.github.ggomarighetti/jpa-rsql-search-api)
 [![GitHub Release](https://img.shields.io/github/v/release/ggomarighetti/jpa-rsql-search?display_name=tag)](https://github.com/ggomarighetti/jpa-rsql-search/releases)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/ggomarighetti/jpa-rsql-search/badge)](https://scorecard.dev/viewer/?uri=github.com/ggomarighetti/jpa-rsql-search)
 [![Java 17+](https://img.shields.io/badge/Java-17%2B-007396)](https://adoptium.net/)
 [![Spring Boot 4](https://img.shields.io/badge/Spring%20Boot-4.x-6DB33F)](https://spring.io/projects/spring-boot)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -86,6 +87,7 @@ public search contract around it.
 [Configuration](#configuration) |
 [Error Handling](#error-handling) |
 [Customization](#customization) |
+[Security](#security) |
 [Project Status](#project-status)
 
 ## Installation
@@ -95,16 +97,20 @@ Maven:
 ```xml
 <dependency>
   <groupId>io.github.ggomarighetti</groupId>
-  <artifactId>jpa-rsql-search</artifactId>
-  <version>1.0.1</version>
+  <artifactId>jpa-rsql-search-spring-boot-starter</artifactId>
+  <version>2.0.0</version>
 </dependency>
 ```
 
 Gradle Kotlin DSL:
 
 ```kotlin
-implementation("io.github.ggomarighetti:jpa-rsql-search:1.0.1")
+implementation("io.github.ggomarighetti:jpa-rsql-search-spring-boot-starter:2.0.0")
 ```
+
+The starter brings in the API, core compiler, JPA validation, and default
+Perplexhub backend. Applications that do not use Spring Boot can depend on the
+individual `jpa-rsql-search-*` modules instead.
 
 ## Quick Example
 
@@ -172,7 +178,7 @@ public class ProductSearchUseCase {
 | Type | Purpose |
 |---|---|
 | `SearchDefinition<T>` | Immutable contract for one entity and search use case |
-| `SearchDefinitionFactory` | Creates definitions with application-wide path limits |
+| `SearchDefinition.Factory` | Creates definitions with application-wide path limits |
 | `SearchCompiler` | Validates and compiles a complete request |
 | `CompiledSearch<T>` | Resulting `Specification<T>` and validated `Pageable` |
 | `SearchPolicy` | Global and definition-local protection limits |
@@ -189,7 +195,7 @@ SearchDefinition<Product> definition = SearchDefinition.builder()
 ```
 
 In Spring Boot applications, prefer the auto-configured
-`SearchDefinitionFactory` when definitions should inherit global path-depth
+`SearchDefinition.Factory` when definitions should inherit global path-depth
 policy during construction:
 
 ```java
@@ -545,7 +551,7 @@ defaultUnpagedSize, translatedSort)`. Use
 
 Setting `jpa.rsql.search.rsql.enabled=false` disables the built-in RSQL engine,
 Perplexhub backend, and related RSQL infrastructure. In that mode the
-auto-configuration still creates `SearchDefinitionFactory`, but it creates
+auto-configuration still creates `SearchDefinition.Factory`, but it creates
 `SearchCompiler` only when the application provides its own `SearchRsqlEngine`
 bean.
 
@@ -812,17 +818,31 @@ compiler, or a `RsqlParserFactory` through `SearchRsqlEngineCustomizer` to
 replace parser construction. Register one or more `SearchDefinitionValidator`
 beans to enforce additional runtime checks on completed definitions.
 
+## Security
+
+Report suspected vulnerabilities privately through
+[GitHub Security Advisories](https://github.com/ggomarighetti/jpa-rsql-search/security/advisories/new);
+do not open a public issue. The supported-version policy, response targets, and
+disclosure process are documented in [SECURITY.md](SECURITY.md).
+
+Release assets include SHA-256 checksums, CycloneDX SBOMs, build information,
+and Sigstore attestations. Verification instructions are in
+[docs/RELEASE_SECURITY.md](docs/RELEASE_SECURITY.md), and the project's OpenSSF
+control mapping is in [docs/OPENSSF.md](docs/OPENSSF.md).
+
 ## Project Status
 
-`jpa-rsql-search` is a stable 1.x library:
+`jpa-rsql-search` is a modular 2.x library:
 
-- current version: `1.0.1`;
-- releases are published to Maven Central under
-  `io.github.ggomarighetti:jpa-rsql-search`;
+- current development line: `2.0.0`;
+- releases are published as `io.github.ggomarighetti:jpa-rsql-search-*`
+  modules, with `jpa-rsql-search-spring-boot-starter` as the usual entry point;
 - the public API follows Semantic Versioning;
 - Spring Boot configuration metadata is included in the generated JAR;
-- the implementation is covered by unit, fuzz/property-style, and PostgreSQL
-  integration tests.
+- the implementation is covered by unit, property, Jazzer/ClusterFuzzLite, and
+  PostgreSQL integration tests;
+- Scorecard, CodeQL, OSV-Scanner, dependency review, SBOM generation, and
+  reproducible-build checks run in GitHub Actions.
 
 ## Build
 
@@ -840,9 +860,9 @@ Generate JaCoCo coverage for unit and integration tests:
 ./mvnw -Pcoverage verify
 ```
 
-The XML report is written to `target/site/jacoco/jacoco.xml`; the HTML report is
-written to `target/site/jacoco/index.html`. CI uploads the JaCoCo report and
-JUnit XML test results to Codecov, and runs SonarQube Cloud analysis when the
+The aggregate XML report is written to
+`integration-tests/target/site/jacoco-aggregate/jacoco.xml`. CI uploads JaCoCo
+and JUnit results to Codecov, and runs SonarQube Cloud analysis when the
 repository has a `SONAR_TOKEN` secret configured.
 
 Verify public Javadocs and release checks:
@@ -851,12 +871,17 @@ Verify public Javadocs and release checks:
 ./mvnw -Prelease verify
 ```
 
+Generate CycloneDX SBOMs and reproducible-build metadata:
+
+```bash
+./mvnw -Psbom,reproducible -DskipTests package
+```
+
 ## Contributing
 
 Issues, bug reports, documentation improvements, and pull requests are welcome.
-Please keep proposed API changes small, explicit, and accompanied by tests or
-documentation updates where possible. PR titles should follow Conventional
-Commits so release notes and version bumps remain predictable.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, review
+policy, Conventional Commit rules, and required DCO sign-off.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Supported versions
+
+The latest stable major release receives security fixes. After a new major
+release, the previous major receives security-only fixes for six months.
+Older releases are unsupported.
+
+Pre-release and snapshot builds are development artifacts and should not be
+used in production.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability.
+
+Use GitHub's private vulnerability reporting form:
+
+https://github.com/ggomarighetti/jpa-rsql-search/security/advisories/new
+
+Include, when possible:
+
+- the affected version and module;
+- impact and expected attacker capabilities;
+- a minimal reproducer or proof of concept;
+- suggested mitigations;
+- whether the report may credit you publicly.
+
+The project aims to:
+
+- acknowledge reports within 3 business days;
+- provide an initial assessment within 7 business days;
+- keep the reporter informed at least every 14 days;
+- coordinate disclosure within 90 days, or sooner when a fix is available.
+
+Target remediation times after confirmation are 14 days for critical issues,
+30 days for high severity issues, and 60 days for medium severity issues.
+Actual timing may vary with complexity and safe-release requirements.
+
+## Disclosure and advisories
+
+Confirmed vulnerabilities are handled through a private GitHub Security
+Advisory. Public advisories identify affected versions, impact, mitigations,
+fixed versions, and reporter credit unless anonymity was requested. A CVE is
+requested when appropriate.
+
+Security fixes are called out explicitly in release notes. The project will not
+silently suppress a confirmed exploitable vulnerability.
+
+## Dependency and static-analysis findings
+
+Critical or high severity exploitable findings block a release. Exceptions must
+be documented with scope, rationale, owner, and a review date. Findings that do
+not affect this project should be documented as non-exploitable and, when a
+release contains the affected component, represented in VEX data.
+
+See [Dependency Policy](docs/DEPENDENCY_POLICY.md) for dependency and license
+handling.
+
+## Release verification
+
+Published Maven Central artifacts are signed with PGP. GitHub releases also
+publish checksums, CycloneDX SBOMs, and GitHub artifact attestations when the
+release workflow is used.
+
+Verification instructions are in
+[Release Security](docs/RELEASE_SECURITY.md).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,31 @@
+# Support
+
+## Where to ask
+
+- Use [GitHub Discussions](https://github.com/ggomarighetti/jpa-rsql-search/discussions)
+  for usage questions and design discussion.
+- Use [GitHub Issues](https://github.com/ggomarighetti/jpa-rsql-search/issues)
+  for reproducible defects and feature requests.
+- Use private vulnerability reporting for security issues as described in
+  [SECURITY.md](SECURITY.md).
+
+## Bug reports
+
+Include:
+
+- library version and module;
+- Java, Spring Boot, Spring Data JPA, Hibernate, and database versions;
+- configuration relevant to the failure;
+- a minimal reproducer;
+- expected and actual behavior;
+- full exception type and sanitized stack trace.
+
+Do not include credentials, private data, or production queries.
+
+## Support lifecycle
+
+The latest stable major release receives fixes. The previous major receives
+security-only fixes for six months after the next major is released. Unsupported
+versions may still receive community assistance, but no fixes are guaranteed.
+
+Support is community-based and has no guaranteed response time.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,55 @@
+# Architecture
+
+`jpa-rsql-search` turns explicitly allowed search input into bounded Spring Data
+JPA specifications.
+
+## Modules
+
+- `jpa-rsql-search-api`: public definitions, policies, paths, filtering,
+  sorting, paging, and query contracts.
+- `jpa-rsql-search-rsql-spi`: backend-neutral RSQL AST, parser contracts,
+  operator metadata, and JPA predicate bindings.
+- `jpa-rsql-search-core`: guarded compilation, validation, engine construction,
+  and protection limits.
+- `jpa-rsql-search-jpa-validation`: JPA metamodel validation.
+- `jpa-rsql-search-perplexhub`: Perplexhub parser/backend integration.
+- `jpa-rsql-search-spring-boot-starter`: auto-configuration and configuration
+  metadata.
+- `integration-tests`: architecture, consumer, and PostgreSQL verification; it
+  is never published.
+
+The intended dependency direction is:
+
+```text
+api <- rsql-spi <- core <- jpa-validation
+                    ^
+                    |
+                perplexhub
+                    ^
+                    |
+            spring-boot-starter
+```
+
+## Runtime flow
+
+1. The application defines an allowlist with `SearchDefinition`.
+2. Definition validators confirm paths, operators, topology, and types.
+3. The parser creates a bounded RSQL AST.
+4. Guards enforce size, depth, value, path, join, and complexity limits.
+5. A backend compiles the validated AST into a JPA `Specification`.
+6. Application-owned mandatory predicates are combined with logical `AND`.
+7. Paging, sorting, and query text are validated before execution.
+
+## Trust boundaries
+
+HTTP input, RSQL expressions, query text, sorting, and paging are untrusted.
+Application definitions and mandatory predicates are trusted policy. Backend
+implementations and custom operators are privileged extension points and must
+be registered explicitly.
+
+The library does not authenticate users, authorize business actions, own a
+database connection, or execute HTTP requests. The consuming application owns
+those boundaries.
+
+Architecture rules and jar-boundary integration tests enforce module
+separation. SonarQube Cloud also tracks the intended architecture model.

--- a/docs/DEPENDENCY_POLICY.md
+++ b/docs/DEPENDENCY_POLICY.md
@@ -1,0 +1,42 @@
+# Dependency Policy
+
+## Selection
+
+Dependencies must have a clear project need, compatible license, maintained
+upstream, published source, and a support range compatible with Java 17 and the
+supported Spring ecosystem.
+
+Prefer:
+
+- standard Java or Spring capabilities;
+- dependencies managed by the Spring Boot BOM;
+- small, focused libraries over broad frameworks;
+- releases available from Maven Central.
+
+Avoid unmaintained, unpublished, vendored, snapshot, or repository-local
+dependencies in released artifacts.
+
+## Tracking and updates
+
+Maven POMs are the authoritative dependency manifests. Dependabot monitors Maven
+and GitHub Actions weekly. Pull requests introducing dependencies are reviewed
+for vulnerabilities, provenance, maintenance, transitive impact, and licenses.
+
+## Vulnerability thresholds
+
+- Critical and high exploitable vulnerabilities block merge and release.
+- Medium findings require triage and a remediation plan within 60 days.
+- Low findings are handled according to impact and release cadence.
+- A suppression requires evidence, owner, scope, rationale, and review date.
+- Non-exploitable findings should be represented in VEX for released software.
+
+## Licenses
+
+MIT, BSD, Apache-2.0, ISC, and similarly permissive licenses are normally
+acceptable. Copyleft, source-available, unknown, or conflicting licenses require
+explicit review before adoption.
+
+## Release gate
+
+Release builds generate a CycloneDX SBOM and run software composition analysis.
+Applicable policy violations must be resolved before publication.

--- a/docs/OPENSSF.md
+++ b/docs/OPENSSF.md
@@ -1,0 +1,24 @@
+# OpenSSF Adoption
+
+The project uses OpenSSF OSPS Baseline 2026.02.19 as its security-control
+catalog and OpenSSF Scorecard as continuous automated feedback.
+
+## Implemented evidence
+
+- public source, history, issue tracker, and discussions;
+- MIT licensing in source and release artifacts;
+- protected primary branch and required CI;
+- security, contribution, governance, support, dependency, and secrets policy;
+- private vulnerability reporting and coordinated disclosure;
+- Dependabot, dependency review, OSV, CodeQL, SonarQube, and secret scanning;
+- full-SHA GitHub Action references and least-privilege tokens;
+- CycloneDX SBOMs, PGP signatures, checksums, and artifact attestations;
+- architecture, threat model, property testing, and coverage-guided fuzzing.
+
+## Known maturity limitation
+
+The project currently has one maintainer. It does not claim controls that
+require independent human approval, a bus factor of two, or multiple
+unassociated contributors.
+
+Scorecard findings are treated as risk signals, not as a target to game.

--- a/docs/RELEASE_SECURITY.md
+++ b/docs/RELEASE_SECURITY.md
@@ -1,0 +1,47 @@
+# Release Security and Verification
+
+## Published evidence
+
+A release created by the project workflow includes:
+
+- Maven POM, binary JAR, sources JAR, and Javadocs JAR;
+- PGP signatures required by Maven Central;
+- SHA-256 checksums;
+- CycloneDX JSON SBOMs;
+- GitHub/Sigstore artifact-attestation bundles;
+- release notes identifying security changes.
+
+## Verify Maven Central signatures
+
+Download an artifact and its `.asc` signature from Maven Central, import the
+maintainer's published key, and run:
+
+```bash
+gpg --verify artifact.jar.asc artifact.jar
+```
+
+Confirm the key fingerprint through an independent maintainer identity channel.
+
+## Verify GitHub provenance
+
+With GitHub CLI:
+
+```bash
+gh attestation verify artifact.jar \
+  --repo ggomarighetti/jpa-rsql-search
+```
+
+Verification must identify this repository and the release workflow. Also
+compare the artifact's SHA-256 digest with the release checksum manifest.
+
+## Build from source
+
+Use the source tag associated with the release:
+
+```bash
+./mvnw -Pcoverage,release verify
+./mvnw -Ppublication,sbom -DskipTests deploy
+```
+
+The release tag must be signed and point to the commit identified by the
+provenance.

--- a/docs/SECRETS_POLICY.md
+++ b/docs/SECRETS_POLICY.md
@@ -1,0 +1,19 @@
+# Secrets and Credentials Policy
+
+- Never commit credentials, private keys, access tokens, passwords, or
+  production connection strings.
+- Store release credentials only in GitHub Actions secrets or protected
+  environments.
+- Grant secrets only to jobs that require them.
+- Pull request workflows from untrusted code must not receive release secrets or
+  write tokens.
+- Prefer short-lived OIDC credentials and artifact attestations over persistent
+  signing secrets when the target service supports them.
+- Rotate a credential immediately after suspected exposure and revoke the old
+  value before investigating further.
+- Review long-lived release credentials at least every six months.
+- Use separate credentials for Maven Central, GitHub Packages, and PGP signing.
+- Do not print secrets, complete GitHub contexts, or secret-derived values in
+  logs.
+
+GitHub secret scanning and push protection are required repository controls.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,86 @@
+# Threat Model
+
+## Assets
+
+- confidentiality and integrity of persisted application data;
+- availability of search endpoints and databases;
+- correctness of mandatory application predicates;
+- integrity of published Maven artifacts and release metadata;
+- repository and release credentials.
+
+## Attackers and inputs
+
+The primary attacker is an unauthenticated or low-privilege API consumer able to
+control RSQL filters, query text, sort orders, and paging. Contributors and
+compromised dependencies are relevant supply-chain threats.
+
+## Main threats and controls
+
+### Unauthorized data access
+
+Threats include selecting undeclared fields, traversing sensitive relationships,
+using unexpected operators, or removing tenant predicates.
+
+Controls:
+
+- explicit `SearchDefinition` allowlists;
+- validated JPA paths and topology;
+- application predicates combined with `AND`;
+- no reflection-based exposure of arbitrary fields.
+
+### Resource exhaustion
+
+Threats include deeply nested ASTs, large `IN` lists, expensive wildcard
+patterns, unbounded paging, relation sorting, and excessive joins.
+
+Controls:
+
+- limits for input length, AST depth/nodes, comparisons, arguments, joins,
+  wildcard use, sorting, page size, and offset;
+- unpaged requests disabled by default;
+- to-many filtering and sorting restricted;
+- property, regression, integration, and coverage-guided fuzz tests.
+
+### Parser and type confusion
+
+Threats include malformed encodings, unexpected parser exceptions, ambiguous
+custom operators, and unsafe conversions.
+
+Controls:
+
+- structured exceptions;
+- operator arity and type metadata;
+- explicit conversion service;
+- parser corpus and fuzz testing;
+- backend validation before execution.
+
+### Information disclosure
+
+Raw persistence exceptions or query details may reveal schema or data.
+Consumers must map structured validation exceptions at the application boundary
+and must not return raw SQL or persistence errors.
+
+### Supply-chain compromise
+
+Threats include vulnerable dependencies, mutable GitHub Actions, over-privileged
+tokens, release tampering, and leaked credentials.
+
+Controls:
+
+- Dependabot, dependency review, OSV, CodeQL, and SonarQube;
+- Actions pinned to full commit SHAs;
+- read-only tokens by default;
+- PGP signatures, checksums, SBOMs, and artifact attestations;
+- secret scanning and push protection.
+
+## Residual risks
+
+- The project currently has one maintainer, so independent human review and
+  continuity guarantees are limited.
+- Consumers can create unsafe custom backends or mandatory predicates.
+- Database plans and costs depend on the consumer's schema, indexes, and data.
+- No finite limit eliminates all denial-of-service risk; applications should
+  also apply authentication, rate limits, timeouts, and database protections.
+
+This model is reviewed for every major release and after confirmed security
+incidents.

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -10,6 +10,7 @@
   <artifactId>jpa-rsql-search-integration-tests</artifactId>
   <name>jpa-rsql-search integration tests</name>
   <properties>
+    <cyclonedx.skip>true</cyclonedx.skip>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
   <dependencies>

--- a/jpa-rsql-search-core/pom.xml
+++ b/jpa-rsql-search-core/pom.xml
@@ -58,6 +58,12 @@
       <version>${expressly.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.code-intelligence</groupId>
+      <artifactId>jazzer-junit</artifactId>
+      <version>${jazzer.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/jpa-rsql-search-core/src/test/java/io/github/ggomarighetti/jparsqlsearch/compile/RsqlFuzzTest.java
+++ b/jpa-rsql-search-core/src/test/java/io/github/ggomarighetti/jparsqlsearch/compile/RsqlFuzzTest.java
@@ -1,0 +1,32 @@
+package io.github.ggomarighetti.jparsqlsearch.compile;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import io.github.ggomarighetti.jparsqlsearch.definition.SearchDefinition;
+import io.github.ggomarighetti.jparsqlsearch.integration.bench.domain.Product;
+import io.github.ggomarighetti.jparsqlsearch.property.SearchPropertyFixtures;
+import io.github.ggomarighetti.jparsqlsearch.unit.TestRsqlEngines;
+import java.nio.charset.StandardCharsets;
+
+class RsqlFuzzTest {
+    private static final int MAX_INPUT_BYTES = 16_384;
+    private static final RsqlSearchGuard GUARD = new RsqlSearchGuard(TestRsqlEngines.defaults());
+    private static final SearchDefinition<Product> DEFINITION = SearchPropertyFixtures.rsqlDefinition();
+
+    @FuzzTest(maxDuration = "30s")
+    void arbitraryInputNeverEscapesUnexpectedThrowable(byte[] bytes) {
+        if (bytes.length > MAX_INPUT_BYTES) {
+            return;
+        }
+
+        String input = new String(bytes, StandardCharsets.UTF_8);
+        try {
+            GUARD.specification(input, DEFINITION);
+        } catch (Throwable throwable) {
+            if (!SearchPropertyFixtures.isExpectedRsqlThrowable(throwable)) {
+                fail("Unexpected throwable for fuzzed RSQL input", throwable);
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputTimestamp>2026-06-15T17:29:14Z</project.build.outputTimestamp>
     <maven.compiler.release>17</maven.compiler.release>
     <spring.boot.version>4.1.0</spring.boot.version>
     <rsql.parser.version>2.4.0</rsql.parser.version>
@@ -66,6 +67,9 @@
     <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
     <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
     <jreleaser.maven.plugin.version>1.24.0</jreleaser.maven.plugin.version>
+    <cyclonedx.maven.plugin.version>2.9.2</cyclonedx.maven.plugin.version>
+    <maven.artifact.plugin.version>3.6.1</maven.artifact.plugin.version>
+    <jazzer.version>0.30.0</jazzer.version>
     <sonar.projectKey>ggomarighetti_jpa-rsql-search</sonar.projectKey>
     <sonar.projectName>jpa-rsql-search</sonar.projectName>
     <sonar.organization>ggomarighetti</sonar.organization>
@@ -152,6 +156,51 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-build-environment</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[17,)</version>
+                </requireJavaVersion>
+                <requireMavenVersion>
+                  <version>[3.9.0,)</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-project-license</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${maven.multiModuleProjectDirectory}</directory>
+                  <filtering>false</filtering>
+                  <includes>
+                    <include>LICENSE</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -249,6 +298,7 @@
             <configuration>
               <doclint>all</doclint>
               <failOnWarnings>true</failOnWarnings>
+              <notimestamp>true</notimestamp>
               <show>public</show>
             </configuration>
             <executions>
@@ -258,6 +308,81 @@
                 <goals>
                   <goal>javadoc</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>sbom</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <version>${cyclonedx.maven.plugin.version}</version>
+            <configuration>
+              <projectType>library</projectType>
+              <schemaVersion>1.6</schemaVersion>
+              <includeBomSerialNumber>false</includeBomSerialNumber>
+              <includeCompileScope>true</includeCompileScope>
+              <includeProvidedScope>true</includeProvidedScope>
+              <includeRuntimeScope>true</includeRuntimeScope>
+              <includeSystemScope>false</includeSystemScope>
+              <includeTestScope>false</includeTestScope>
+              <includeLicenseText>false</includeLicenseText>
+              <outputReactorProjects>true</outputReactorProjects>
+              <outputFormat>json</outputFormat>
+              <outputName>bom</outputName>
+              <skipNotDeployed>true</skipNotDeployed>
+            </configuration>
+            <executions>
+              <execution>
+                <id>generate-cyclonedx-sboms</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>makeAggregateBom</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>reproducible</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-artifact-plugin</artifactId>
+            <version>${maven.artifact.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>check-reproducible-build-plan</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>check-buildplan</goal>
+                </goals>
+                <configuration>
+                  <diagnose>true</diagnose>
+                  <tasks>
+                    <task>deploy</task>
+                  </tasks>
+                </configuration>
+              </execution>
+              <execution>
+                <id>generate-buildinfo</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>buildinfo</goal>
+                </goals>
+                <configuration>
+                  <reproducible>true</reproducible>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -294,6 +419,7 @@
             <configuration>
               <doclint>all</doclint>
               <failOnWarnings>true</failOnWarnings>
+              <notimestamp>true</notimestamp>
               <show>public</show>
             </configuration>
             <executions>

--- a/scripts/configure-github-security.ps1
+++ b/scripts/configure-github-security.ps1
@@ -1,0 +1,58 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [string]$Repository = "ggomarighetti/jpa-rsql-search",
+    [switch]$EnableShaPinning
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw "GitHub CLI (gh) is required."
+}
+
+gh auth status | Out-Null
+
+if ($PSCmdlet.ShouldProcess($Repository, "set read-only default workflow permissions")) {
+    gh api --method PUT "repos/$Repository/actions/permissions/workflow" `
+        -f default_workflow_permissions=read `
+        -F can_approve_pull_request_reviews=false | Out-Null
+}
+
+if ($PSCmdlet.ShouldProcess($Repository, "restrict Actions to the reviewed allowlist")) {
+    gh api --method PUT "repos/$Repository/actions/permissions" `
+        -F enabled=true `
+        -f allowed_actions=selected | Out-Null
+
+    $allowlist = [ordered]@{
+        github_owned_allowed = $true
+        verified_allowed = $false
+        patterns_allowed = @(
+            "codecov/codecov-action@*"
+            "cue-lang/setup-cue@*"
+            "google/clusterfuzzlite/*@*"
+            "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@*"
+            "googleapis/release-please-action@*"
+            "ossf/scorecard-action@*"
+        )
+    } | ConvertTo-Json -Depth 10
+
+    $allowlist | gh api --method PUT `
+        "repos/$Repository/actions/permissions/selected-actions" `
+        --input - | Out-Null
+}
+
+if ($EnableShaPinning) {
+    if ($PSCmdlet.ShouldProcess($Repository, "require full commit SHAs for Actions")) {
+        gh api --method PUT "repos/$Repository/actions/permissions" `
+            -F enabled=true `
+            -f allowed_actions=selected `
+            -F sha_pinning_required=true | Out-Null
+    }
+}
+else {
+    Write-Warning "SHA pin enforcement was not enabled. Run again with -EnableShaPinning only after this branch is merged into master."
+}
+
+gh api "repos/$Repository/actions/permissions"
+gh api "repos/$Repository/actions/permissions/workflow"
+gh api "repos/$Repository/actions/permissions/selected-actions"

--- a/scripts/verify-reproducible-build.sh
+++ b/scripts/verify-reproducible-build.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf "${work}"' EXIT
+
+build_and_hash() {
+  local output="$1"
+
+  cd "${root}"
+  ./mvnw -B -ntp -nsu clean package \
+    -DskipTests \
+    -Ppublication,sbom,reproducible
+
+  find . -type f \
+    \( -path '*/target/*.jar' \
+       -o -path '*/target/*.pom' \
+       -o -path '*/target/*-cyclonedx.json' \
+       -o -path '*/target/*.buildinfo' \) \
+    ! -path './integration-tests/target/*' \
+    -print0 \
+    | sort -z \
+    | xargs -0 sha256sum \
+    | sed "s#  \\./#  #" \
+    > "${output}"
+}
+
+build_and_hash "${work}/first.sha256"
+build_and_hash "${work}/second.sha256"
+
+if ! diff -u "${work}/first.sha256" "${work}/second.sha256"; then
+  echo "Reproducible-build verification failed." >&2
+  exit 1
+fi
+
+echo "Reproducible-build verification passed for all published artifacts."

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -1,0 +1,133 @@
+header:
+  schema-version: 2.2.0
+  last-updated: '2026-06-21'
+  last-reviewed: '2026-06-21'
+  url: https://raw.githubusercontent.com/ggomarighetti/jpa-rsql-search/refs/heads/master/security-insights.yml
+  comment: |
+    Single-repository Security Insights document for jpa-rsql-search.
+
+project:
+  name: jpa-rsql-search
+  homepage: https://github.com/ggomarighetti/jpa-rsql-search
+  roadmap: https://github.com/ggomarighetti/jpa-rsql-search/issues
+  administrators:
+    - name: Guillermo Orue Marighetti
+      affiliation: Independent
+      social: https://github.com/ggomarighetti
+      primary: true
+  documentation:
+    quickstart-guide: https://github.com/ggomarighetti/jpa-rsql-search#quick-example
+    detailed-guide: https://github.com/ggomarighetti/jpa-rsql-search#api-reference
+    code-of-conduct: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/CODE_OF_CONDUCT.md
+    design: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/docs/ARCHITECTURE.md
+    release-process: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/docs/RELEASE_SECURITY.md
+    support-policy: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/SUPPORT.md
+    signature-verification: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/docs/RELEASE_SECURITY.md
+  repositories:
+    - name: jpa-rsql-search
+      url: https://github.com/ggomarighetti/jpa-rsql-search
+      comment: |
+        Authoritative source, build, security, and release repository.
+  vulnerability-reporting:
+    reports-accepted: true
+    bug-bounty-available: false
+    contact:
+      name: jpa-rsql-search maintainer
+      social: https://github.com/ggomarighetti
+      primary: true
+    policy: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/SECURITY.md
+    in-scope:
+      - authorization bypass caused by search compilation
+      - denial of service caused by unbounded input processing
+      - unsafe path, operator, or type handling
+      - release or build pipeline compromise
+    out-of-scope:
+      - vulnerabilities in unsupported versions
+      - unsafe configuration in a consuming application
+      - reports without a security impact
+
+repository:
+  url: https://github.com/ggomarighetti/jpa-rsql-search
+  status: active
+  bug-fixes-only: false
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  no-third-party-packages: false
+  core-team:
+    - name: Guillermo Orue Marighetti
+      affiliation: Independent
+      social: https://github.com/ggomarighetti
+      primary: true
+  documentation:
+    contributing-guide: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/CONTRIBUTING.md
+    review-policy: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/CONTRIBUTING.md#review
+    security-policy: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/SECURITY.md
+    governance: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/GOVERNANCE.md
+    dependency-management-policy: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/docs/DEPENDENCY_POLICY.md
+  license:
+    url: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/LICENSE
+    expression: MIT
+  release:
+    changelog: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/CHANGELOG.md
+    automated-pipeline: true
+    attestations:
+      - name: GitHub artifact provenance
+        predicate-uri: https://slsa.dev/provenance/v1
+        location: https://github.com/ggomarighetti/jpa-rsql-search/attestations
+        comment: Sigstore bundles are also attached to each GitHub release.
+      - name: CycloneDX SBOM
+        predicate-uri: https://cyclonedx.org/bom
+        location: https://github.com/ggomarighetti/jpa-rsql-search/releases
+        comment: Each release publishes module and aggregate CycloneDX JSON SBOMs.
+    distribution-points:
+      - uri: https://central.sonatype.com/namespace/io.github.ggomarighetti
+        comment: Maven Central
+      - uri: https://github.com/ggomarighetti/jpa-rsql-search/releases
+        comment: GitHub releases and verification evidence
+    license:
+      url: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/LICENSE
+      expression: MIT
+  security:
+    assessments:
+      self:
+        evidence: https://github.com/ggomarighetti/jpa-rsql-search/blob/master/docs/OPENSSF.md
+        date: '2026-06-21'
+        comment: |
+          Self-assessed against OSPS Baseline 2026.02.19.
+    champions:
+      - name: Guillermo Orue Marighetti
+        social: https://github.com/ggomarighetti
+        primary: true
+    tools:
+      - name: Dependabot
+        type: SCA
+        rulesets:
+          - built-in
+        integration:
+          adhoc: true
+          ci: true
+          release: true
+      - name: OSV-Scanner
+        type: SCA
+        rulesets:
+          - OSV.dev
+        integration:
+          adhoc: true
+          ci: true
+          release: true
+      - name: CodeQL
+        type: SAST
+        rulesets:
+          - default
+        integration:
+          adhoc: true
+          ci: true
+          release: true
+      - name: SonarQube Cloud
+        type: SAST
+        rulesets:
+          - Sonar way
+        integration:
+          adhoc: true
+          ci: true
+          release: true


### PR DESCRIPTION
## Summary

- establish OpenSSF-aligned security, governance, support, contribution, architecture, threat-model, dependency, and secrets policies
- harden GitHub Actions with immutable SHAs and least-privilege permissions; add Scorecard, CodeQL, Dependency Review, OSV, DCO, Security Insights validation, actionlint, and reproducible-build checks
- publish CycloneDX SBOMs, SHA-256 manifests, buildinfo, Sigstore provenance/SBOM attestations, and release verification guidance
- add Jazzer and ClusterFuzzLite coverage-guided fuzzing for untrusted RSQL input
- update the modular v2 README and include MIT license metadata in binary JARs

## Validation

- `./mvnw -Pcoverage,sbom,reproducible verify`
- `./mvnw -Ppublication,sbom,reproducible -DskipTests deploy`
- OSV-Scanner v2.4.0 against the aggregate CycloneDX SBOM: no issues found
- Security Insights 2.2.0 validated with the official CUE schema
- actionlint 1.7.12 across all workflows
- two clean publication builds compared bit-for-bit
- ClusterFuzzLite target built in the official JVM image and executed for 100 runs

## Evidence

> Not required
