### PR TITLE
fix(security): keep OSV scanning compatible with SHA enforcement

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -51,15 +51,44 @@ jobs:
           retention-days: 5
 
   scan:
-    name: Scan SBOM
+    name: Scan SBOM / osv-scan
     needs: build-sbom
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
       security-events: write
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
-    with:
-      download-artifact: cyclonedx-sbom
-      scan-args: --sbom=./bom.json
-      fail-on-vuln: true
-      upload-sarif: true
+
+    steps:
+      - name: Download aggregate SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cyclonedx-sbom
+          path: .
+
+      - name: Scan SBOM
+        shell: bash
+        run: |
+          docker run --rm \
+            --volume "${PWD}:/src" \
+            ghcr.io/google/osv-scanner@sha256:5116601dedc01c1c580eb92371883ec052fc4c13c3fbc109d621a63ac416d475 \
+            scan \
+            -L /src/bom.json \
+            --format sarif \
+            --output-file /src/osv-results.sarif
+
+      - name: Upload OSV results artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: osv-scanner-results
+          path: osv-results.sarif
+          retention-days: 5
+          if-no-files-found: error
+
+      - name: Upload OSV results to code scanning
+        if: ${{ always() }}
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: osv-results.sarif

--- a/scripts/configure-github-security.ps1
+++ b/scripts/configure-github-security.ps1
@@ -30,7 +30,6 @@ if ($PSCmdlet.ShouldProcess($Repository, "restrict Actions to the reviewed allow
             "codecov/codecov-action@*"
             "cue-lang/setup-cue@*"
             "google/clusterfuzzlite/*@*"
-            "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@*"
             "googleapis/release-please-action@*"
             "ossf/scorecard-action@*"
         )


### PR DESCRIPTION
## Summary

- replace the third-party reusable OSV workflow, whose internals still use a mutable Action tag
- run the official OSV-Scanner container pinned by digest
- keep artifact download, SARIF upload, and code-scanning publication pinned to immutable SHAs
- remove the obsolete OSV reusable-workflow entry from the Actions allowlist

## Reason

GitHub's repository-wide SHA enforcement correctly rejected the reusable workflow after PR #27 merged. This preserves strict SHA enforcement without weakening the vulnerability scan.