### PR TITLE
fix(security): pin ClusterFuzzLite base image

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder-jvm
+FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:82352abfb9612e938c95b0f3326b8fa8f843bba188d44470671f04a1555b3963
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y maven openjdk-17-jdk \


### PR DESCRIPTION
## Summary

- pin the ClusterFuzzLite OSS-Fuzz JVM builder image to the digest recommended by OpenSSF Scorecard
- remove the remaining mutable container reference reported by the Pinned-Dependencies check

## Validation

- docker manifest inspect resolves the pinned digest successfully
- git diff --check passes