### PR TITLE
ci: raise repository quality gates

### DIFF
--- a/.github/clusterfuzzlite/Dockerfile
+++ b/.github/clusterfuzzlite/Dockerfile
@@ -3,4 +3,4 @@ FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:e3ac22ef17541ca88d404971801c4d
 COPY . $SRC/rsql-jpa-search
 WORKDIR $SRC/rsql-jpa-search
 COPY .github/clusterfuzzlite/build.sh $SRC/build.sh
-RUN chmod +x $SRC/build.sh
+RUN chmod +x "$SRC/build.sh"

--- a/.github/clusterfuzzlite/Dockerfile
+++ b/.github/clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:e3ac22ef17541ca88d404971801c4d8191860f8bf5429f59ebd229a4e6c42cd4
+
+COPY . $SRC/rsql-jpa-search
+WORKDIR $SRC/rsql-jpa-search
+COPY .github/clusterfuzzlite/build.sh $SRC/build.sh
+RUN chmod +x $SRC/build.sh

--- a/.github/clusterfuzzlite/build.sh
+++ b/.github/clusterfuzzlite/build.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$SRC/rsql-jpa-search"
+FUZZER_DIR="$PROJECT_DIR/integration/src/fuzz/java"
+
+cd "$PROJECT_DIR"
+
+./mvnw -B -ntp -nsu -DskipTests install
+./mvnw -B -ntp -nsu -pl integration -DskipTests dependency:copy-dependencies \
+  -DincludeScope=test \
+  -DoutputDirectory="$OUT/lib"
+
+mkdir -p "$OUT/classes" "$OUT/lib"
+
+find api rsql-spi core jpa-validation perplexhub spring-boot-starter \
+  -path "*/target/*.jar" \
+  ! -name "*-tests.jar" \
+  -exec cp {} "$OUT/lib/" \;
+
+cp /usr/local/bin/jazzer_driver /usr/local/bin/jazzer_agent_deploy.jar "$OUT/"
+
+BUILD_CLASSPATH="$OUT/lib/*"
+
+for fuzzer in "$FUZZER_DIR"/*Fuzzer.java; do
+  fuzzer_basename="$(basename "$fuzzer" .java)"
+  javac -cp "$BUILD_CLASSPATH" -d "$OUT/classes" "$fuzzer"
+
+  cat > "$OUT/$fuzzer_basename" <<EOF
+#!/bin/sh
+# LLVMFuzzerTestOneInput for ClusterFuzzLite fuzzer detection.
+this_dir=\$(dirname "\$0")
+runtime_cp="\$this_dir/classes"
+for jar in "\$this_dir"/lib/*.jar; do
+  runtime_cp="\$runtime_cp:\$jar"
+done
+LD_LIBRARY_PATH="\$JVM_LD_LIBRARY_PATH:\$this_dir" \\
+  "\$this_dir/jazzer_driver" \\
+  --agent_path="\$this_dir/jazzer_agent_deploy.jar" \\
+  --cp="\$runtime_cp" \\
+  --target_class="$fuzzer_basename" \\
+  --jvm_args="-Xmx2048m:-Djava.awt.headless=true" \\
+  "\$@"
+EOF
+  chmod +x "$OUT/$fuzzer_basename"
+done

--- a/.github/clusterfuzzlite/project.yaml
+++ b/.github/clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: jvm

--- a/.github/scripts/summarize-jacoco.py
+++ b/.github/scripts/summarize-jacoco.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Write a compact JaCoCo coverage summary for GitHub Actions."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import sys
+import xml.etree.ElementTree as ET
+
+
+REPORTS = [
+    ("api", Path("api/target/site/jacoco/jacoco.xml")),
+    ("rsql-spi", Path("rsql-spi/target/site/jacoco/jacoco.xml")),
+    ("core", Path("core/target/site/jacoco/jacoco.xml")),
+    ("jpa-validation", Path("jpa-validation/target/site/jacoco/jacoco.xml")),
+    ("perplexhub", Path("perplexhub/target/site/jacoco/jacoco.xml")),
+    ("spring-boot-starter", Path("spring-boot-starter/target/site/jacoco/jacoco.xml")),
+    ("aggregate", Path("integration/target/site/jacoco-aggregate/jacoco.xml")),
+]
+
+
+def coverage(report: Path, counter_type: str) -> str:
+    root = ET.parse(report).getroot()
+    for counter in root.findall("counter"):
+        if counter.attrib["type"] == counter_type:
+            missed = int(counter.attrib["missed"])
+            covered = int(counter.attrib["covered"])
+            total = missed + covered
+            if total == 0:
+                return "100.00%"
+            return f"{covered / total * 100:.2f}%"
+    return "n/a"
+
+
+def build_summary() -> str:
+    lines = [
+        "## Coverage",
+        "",
+        "| Module | Lines | Branches | Report |",
+        "| --- | ---: | ---: | --- |",
+    ]
+    for module, report in REPORTS:
+        if report.exists():
+            line = coverage(report, "LINE")
+            branch = coverage(report, "BRANCH")
+            lines.append(f"| `{module}` | {line} | {branch} | `{report.as_posix()}` |")
+        else:
+            lines.append(f"| `{module}` | missing | missing | `{report.as_posix()}` |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    summary = build_summary()
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(summary)
+    else:
+        sys.stdout.write(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/verify-quality.ps1
+++ b/.github/scripts/verify-quality.ps1
@@ -15,7 +15,7 @@ try {
         & .\mvnw.cmd -B -ntp -nsu "-Pcoverage,release,sbom,reproducible" verify
     }
 
-    & .\mvnw.cmd -B -ntp -nsu -pl integration -am "-Pconsumer-tests" verify
+    & .\mvnw.cmd -B -ntp -nsu -pl integration -am "-Pconsumer-tests" install
     & .\mvnw.cmd -B -ntp -nsu -DskipTests org.apache.maven.plugins:maven-dependency-plugin:3.9.0:analyze
 
     if (-not $SkipDockerChecks) {

--- a/.github/scripts/verify-quality.ps1
+++ b/.github/scripts/verify-quality.ps1
@@ -1,0 +1,44 @@
+param(
+    [switch] $SkipDockerChecks,
+    [switch] $SkipReleaseProfile
+)
+
+$ErrorActionPreference = "Stop"
+
+$root = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+Push-Location $root
+
+try {
+    & .\mvnw.cmd -B -ntp -nsu "-Pcoverage,sbom" verify
+
+    if (-not $SkipReleaseProfile) {
+        & .\mvnw.cmd -B -ntp -nsu "-Pcoverage,release,sbom,reproducible" verify
+    }
+
+    & .\mvnw.cmd -B -ntp -nsu -pl integration -am "-Pconsumer-tests" verify
+    & .\mvnw.cmd -B -ntp -nsu -DskipTests org.apache.maven.plugins:maven-dependency-plugin:3.9.0:analyze
+
+    if (-not $SkipDockerChecks) {
+        if (Get-Command docker -ErrorAction SilentlyContinue) {
+            docker run --rm `
+                --volume "$($root.Path):/repo" `
+                --workdir /repo `
+                rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 `
+                -color
+
+            if (Test-Path (Join-Path $root "target\bom.json")) {
+                docker run --rm `
+                    --volume "$($root.Path):/src" `
+                    ghcr.io/google/osv-scanner@sha256:5116601dedc01c1c580eb92371883ec052fc4c13c3fbc109d621a63ac416d475 `
+                    scan `
+                    -L /src/target/bom.json
+            } else {
+                Write-Warning "Skipping OSV scan because target\bom.json was not generated."
+            }
+        } else {
+            Write-Warning "Docker was not found; skipping actionlint and OSV checks."
+        }
+    }
+} finally {
+    Pop-Location
+}

--- a/.github/scripts/verify-quality.sh
+++ b/.github/scripts/verify-quality.sh
@@ -28,7 +28,7 @@ if [[ "${skip_release}" != "true" ]]; then
   ./mvnw -B -ntp -nsu -Pcoverage,release,sbom,reproducible verify
 fi
 
-./mvnw -B -ntp -nsu -pl integration -am -Pconsumer-tests verify
+./mvnw -B -ntp -nsu -pl integration -am -Pconsumer-tests install
 ./mvnw -B -ntp -nsu -DskipTests org.apache.maven.plugins:maven-dependency-plugin:3.9.0:analyze
 
 if [[ "${skip_docker}" != "true" ]]; then

--- a/.github/scripts/verify-quality.sh
+++ b/.github/scripts/verify-quality.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+skip_docker=false
+skip_release=false
+
+for arg in "$@"; do
+  case "${arg}" in
+    --skip-docker-checks)
+      skip_docker=true
+      ;;
+    --skip-release-profile)
+      skip_release=true
+      ;;
+    *)
+      echo "Unknown argument: ${arg}" >&2
+      exit 2
+      ;;
+  esac
+done
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${root}"
+
+./mvnw -B -ntp -nsu -Pcoverage,sbom verify
+
+if [[ "${skip_release}" != "true" ]]; then
+  ./mvnw -B -ntp -nsu -Pcoverage,release,sbom,reproducible verify
+fi
+
+./mvnw -B -ntp -nsu -pl integration -am -Pconsumer-tests verify
+./mvnw -B -ntp -nsu -DskipTests org.apache.maven.plugins:maven-dependency-plugin:3.9.0:analyze
+
+if [[ "${skip_docker}" != "true" ]]; then
+  if command -v docker >/dev/null 2>&1; then
+    docker run --rm \
+      --volume "${root}:/repo" \
+      --workdir /repo \
+      rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
+      -color
+
+    if [[ -f target/bom.json ]]; then
+      docker run --rm \
+        --volume "${root}:/src" \
+        ghcr.io/google/osv-scanner@sha256:5116601dedc01c1c580eb92371883ec052fc4c13c3fbc109d621a63ac416d475 \
+        scan \
+        -L /src/target/bom.json
+    else
+      echo "Skipping OSV scan because target/bom.json was not generated." >&2
+    fi
+  else
+    echo "Docker was not found; skipping actionlint and OSV checks." >&2
+  fi
+fi

--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -44,22 +44,45 @@ jobs:
           cp .github/clusterfuzzlite/build.sh .clusterfuzzlite/build.sh
 
       - name: Build fuzzers
-        id: build
-        uses: google/clusterfuzzlite/actions/build_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05 # v1
-        with:
-          language: jvm
-          sanitizer: ${{ matrix.sanitizer }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          project-src-path: .
+        env:
+          BUILD_FUZZERS_IMAGE: gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers@sha256:79a88907cce4e93d48b5c5ca97a833686636d07d91b7d82abf9e39ebd96b0b42
+          CFL_CONTAINER: cflite-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.sanitizer }}
+          SANITIZER: ${{ matrix.sanitizer }}
+        run: |
+          docker run --rm --name "$CFL_CONTAINER" \
+            --volume /var/run/docker.sock:/var/run/docker.sock \
+            --volume "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
+            --workdir "${GITHUB_WORKSPACE}" \
+            --env "WORKSPACE=${GITHUB_WORKSPACE}" \
+            --env "PROJECT_SRC_PATH=${GITHUB_WORKSPACE}" \
+            --env "REPOSITORY=${GITHUB_REPOSITORY#*/}" \
+            --env "LANGUAGE=jvm" \
+            --env "SANITIZER=${SANITIZER}" \
+            --env "BAD_BUILD_CHECK=true" \
+            --env "KEEP_UNAFFECTED_FUZZ_TARGETS=true" \
+            --env "LOW_DISK_SPACE=true" \
+            "$BUILD_FUZZERS_IMAGE"
 
       - name: Run fuzzers
-        id: run
-        uses: google/clusterfuzzlite/actions/run_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05 # v1
-        with:
-          language: jvm
-          sanitizer: ${{ matrix.sanitizer }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          fuzz-seconds: ${{ github.event_name == 'schedule' && '300' || '60' }}
-          mode: ${{ github.event_name == 'pull_request' && 'code-change' || 'batch' }}
-          output-sarif: true
-          parallel-fuzzing: true
+        env:
+          CFL_CONTAINER: cflite-run-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.sanitizer }}
+          FUZZ_SECONDS: ${{ github.event_name == 'schedule' && '300' || '60' }}
+          MODE: ${{ github.event_name == 'pull_request' && 'code-change' || 'batch' }}
+          RUN_FUZZERS_IMAGE: gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers@sha256:0c3180277e25dd8637a55270f666fbdac038be38fa736080c95ade75a84e8637
+          SANITIZER: ${{ matrix.sanitizer }}
+        run: |
+          docker run --rm --name "$CFL_CONTAINER" \
+            --volume /var/run/docker.sock:/var/run/docker.sock \
+            --volume "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
+            --workdir "${GITHUB_WORKSPACE}" \
+            --env "WORKSPACE=${GITHUB_WORKSPACE}" \
+            --env "PROJECT_SRC_PATH=${GITHUB_WORKSPACE}" \
+            --env "REPOSITORY=${GITHUB_REPOSITORY#*/}" \
+            --env "LANGUAGE=jvm" \
+            --env "SANITIZER=${SANITIZER}" \
+            --env "FUZZ_SECONDS=${FUZZ_SECONDS}" \
+            --env "MODE=${MODE}" \
+            --env "OUTPUT_SARIF=true" \
+            --env "PARALLEL_FUZZING=true" \
+            --env "LOW_DISK_SPACE=true" \
+            "$RUN_FUZZERS_IMAGE"

--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -61,6 +61,7 @@ jobs:
             --env "BAD_BUILD_CHECK=true" \
             --env "KEEP_UNAFFECTED_FUZZ_TARGETS=true" \
             --env "LOW_DISK_SPACE=true" \
+            --env "NO_CLUSTERFUZZ_DEPLOYMENT=true" \
             "$BUILD_FUZZERS_IMAGE"
 
       - name: Run fuzzers
@@ -85,4 +86,5 @@ jobs:
             --env "OUTPUT_SARIF=true" \
             --env "PARALLEL_FUZZING=true" \
             --env "LOW_DISK_SPACE=true" \
+            --env "NO_CLUSTERFUZZ_DEPLOYMENT=true" \
             "$RUN_FUZZERS_IMAGE"

--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -1,0 +1,65 @@
+name: ClusterFuzzLite
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: "47 3 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: ClusterFuzzLite Jazzer
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: ["address"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Prepare ClusterFuzzLite config
+        run: |
+          mkdir -p .clusterfuzzlite
+          cp .github/clusterfuzzlite/project.yaml .clusterfuzzlite/project.yaml
+          cp .github/clusterfuzzlite/Dockerfile .clusterfuzzlite/Dockerfile
+          cp .github/clusterfuzzlite/build.sh .clusterfuzzlite/build.sh
+
+      - name: Build fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05 # v1
+        with:
+          language: jvm
+          sanitizer: ${{ matrix.sanitizer }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          project-src-path: .
+
+      - name: Run fuzzers
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@82652fb49e77bc29c35da1167bb286e93c6bcc05 # v1
+        with:
+          language: jvm
+          sanitizer: ${{ matrix.sanitizer }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: ${{ github.event_name == 'schedule' && '300' || '60' }}
+          mode: ${{ github.event_name == 'pull_request' && 'code-change' || 'batch' }}
+          output-sarif: true
+          parallel-fuzzing: true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -173,7 +173,7 @@ jobs:
           cache: maven
 
       - name: Verify consumer projects
-        run: ./mvnw -B -ntp -nsu -pl integration -am -Pconsumer-tests verify
+        run: ./mvnw -B -ntp -nsu -pl integration -am -Pconsumer-tests install
 
       - name: Upload consumer compatibility artifacts
         if: ${{ always() }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -147,3 +147,36 @@ jobs:
 
       - name: Test
         run: ./mvnw -B -ntp -nsu test
+
+  consumer-compatibility:
+    name: Consumer compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Java 25
+        uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Verify consumer projects
+        run: ./mvnw -B -ntp -nsu -pl integration -am -Pconsumer-tests verify
+
+      - name: Upload consumer compatibility artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: consumer-compatibility-reports
+          path: |
+            integration/target/invoker-reports/
+            integration/target/it/
+          if-no-files-found: ignore

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -88,6 +88,10 @@ jobs:
             integration/target/failsafe-reports/
           if-no-files-found: ignore
 
+      - name: Summarize coverage
+        if: ${{ always() }}
+        run: python3 .github/scripts/summarize-jacoco.py
+
       - name: Skip Codecov uploads
         if: ${{ env.CODECOV_TOKEN == '' }}
         run: echo "CODECOV_TOKEN secret is not configured; skipping Codecov uploads."
@@ -97,7 +101,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ env.CODECOV_TOKEN }}
-          files: integration/target/site/jacoco-aggregate/jacoco.xml
+          files: api/target/site/jacoco/jacoco.xml,rsql-spi/target/site/jacoco/jacoco.xml,core/target/site/jacoco/jacoco.xml,jpa-validation/target/site/jacoco/jacoco.xml,perplexhub/target/site/jacoco/jacoco.xml,spring-boot-starter/target/site/jacoco/jacoco.xml,integration/target/site/jacoco-aggregate/jacoco.xml
           disable_search: true
           flags: java
           name: java-coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,23 @@ Run the full verification suite:
 ./mvnw verify
 ```
 
+Run the repository quality sweep before opening a pull request:
+
+```bash
+./.github/scripts/verify-quality.sh
+```
+
+On Windows PowerShell:
+
+```powershell
+.\.github\scripts\verify-quality.ps1
+```
+
+The quality sweep runs the normal coverage/SBOM build, the release and
+reproducible-build profiles, consumer-project compatibility checks, dependency
+analysis, and Docker-backed workflow/vulnerability checks when Docker is
+available.
+
 Run coverage and release checks:
 
 ```bash

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -9,6 +9,10 @@
   </parent>
   <artifactId>rsql-jpa-search-api</artifactId>
   <name>rsql-jpa-search API</name>
+  <properties>
+    <jacoco.line.minimum>0.95</jacoco.line.minimum>
+    <jacoco.branch.minimum>0.85</jacoco.branch.minimum>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,8 +27,16 @@
       <artifactId>spring-data-jpa</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-commons</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.validation</groupId>
+      <artifactId>jakarta.validation-api</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.persistence</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,6 +9,10 @@
   </parent>
   <artifactId>rsql-jpa-search-core</artifactId>
   <name>rsql-jpa-search core</name>
+  <properties>
+    <jacoco.line.minimum>0.97</jacoco.line.minimum>
+    <jacoco.branch.minimum>0.98</jacoco.branch.minimum>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,6 +23,11 @@
       <artifactId>rsql-jpa-search-rsql-spi</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.github.nstdio</groupId>
+      <artifactId>rsql-parser</artifactId>
+      <version>${rsql.parser.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>
@@ -33,6 +38,10 @@
     <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-commons</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.persistence</groupId>

--- a/core/src/test/java/io/github/ggomarighetti/rsqljpasearch/compile/RsqlSearchGuardTest.java
+++ b/core/src/test/java/io/github/ggomarighetti/rsqljpasearch/compile/RsqlSearchGuardTest.java
@@ -1,6 +1,7 @@
 package io.github.ggomarighetti.rsqljpasearch.compile;
 
 import io.github.ggomarighetti.rsqljpasearch.unit.TestRsqlEngines;
+import cz.jirutka.rsql.parser.ast.Arity;
 import cz.jirutka.rsql.parser.ast.ComparisonNode;
 import cz.jirutka.rsql.parser.ast.ComparisonOperator;
 import cz.jirutka.rsql.parser.ast.Node;
@@ -443,7 +444,6 @@ class RsqlSearchGuardTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     void rejectsOperatorWithInvalidArity() throws ReflectiveOperationException {
         RsqlOperator pair = RsqlOperator.of("PAIR");
         RsqlOperatorDescriptor descriptor = RsqlOperatorDescriptor.builder(pair)
@@ -458,7 +458,7 @@ class RsqlSearchGuardTest {
         RsqlRulesValidator validator = validator(definition, new RsqlOperatorRegistry(List.of(descriptor)));
 
         List<RsqlValidationError> errors = validator.validate(ast(new ComparisonNode(
-                new ComparisonOperator("=pair=", true),
+                new ComparisonOperator("=pair=", Arity.nary(1)),
                 "email",
                 List.of("person@example.com"))));
 
@@ -735,7 +735,7 @@ class RsqlSearchGuardTest {
                 new SearchProtectionContext(policy, SearchProtectionContext.Mode.PAGE),
                 new RsqlOperatorRegistry(List.of(descriptor)));
         RsqlAst comparison = astUnchecked(new ComparisonNode(
-                new ComparisonOperator("=pair=", true),
+                new ComparisonOperator("=pair=", Arity.nary(1)),
                 "email",
                 List.of("person@example.com")));
 

--- a/core/src/test/java/io/github/ggomarighetti/rsqljpasearch/compile/SearchSpecificationSortingTest.java
+++ b/core/src/test/java/io/github/ggomarighetti/rsqljpasearch/compile/SearchSpecificationSortingTest.java
@@ -104,10 +104,12 @@ class SearchSpecificationSortingTest {
         return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[] {type}, handler);
     }
 
+    @SuppressWarnings("unchecked")
     private static Root<TestTypes.Product> namedRoot(String name, RecordingCriteriaBuilder builder) {
         return proxy(Root.class, pathHandler(name, builder));
     }
 
+    @SuppressWarnings("unchecked")
     private static InvocationHandler pathHandler(String name, RecordingCriteriaBuilder builder) {
         return (proxy, method, args) -> switch (method.getName()) {
             case "get" -> {
@@ -123,6 +125,7 @@ class SearchSpecificationSortingTest {
         };
     }
 
+    @SuppressWarnings("unchecked")
     private static Expression<?> expression(String name) {
         return proxy(Expression.class, (proxy, method, args) -> switch (method.getName()) {
             case "as" -> expression(name);
@@ -155,6 +158,7 @@ class SearchSpecificationSortingTest {
             this.resultType = resultType;
         }
 
+        @SuppressWarnings("unchecked")
         private CriteriaQuery<T> proxy() {
             return SearchSpecificationSortingTest.proxy(CriteriaQuery.class, (proxy, method, args) -> {
                 if ("getResultType".equals(method.getName())) {
@@ -177,6 +181,7 @@ class SearchSpecificationSortingTest {
         private final List<Class<?>> treatedTypes = new ArrayList<>();
         private final List<String> orderCalls = new ArrayList<>();
 
+        @SuppressWarnings("unchecked")
         private CriteriaBuilder proxy() {
             return SearchSpecificationSortingTest.proxy(CriteriaBuilder.class, (proxy, method, args) -> switch (method.getName()) {
                 case "treat" -> {
@@ -198,6 +203,7 @@ class SearchSpecificationSortingTest {
             });
         }
 
+        @SuppressWarnings("unchecked")
         private CriteriaBuilder.Case<Integer> selectCase() {
             return SearchSpecificationSortingTest.proxy(
                     CriteriaBuilder.Case.class,

--- a/integration/src/fuzz/java/RsqlSearchFuzzer.java
+++ b/integration/src/fuzz/java/RsqlSearchFuzzer.java
@@ -1,0 +1,54 @@
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import io.github.ggomarighetti.rsqljpasearch.compile.SearchCompiler;
+import io.github.ggomarighetti.rsqljpasearch.definition.SearchDefinition;
+import io.github.ggomarighetti.rsqljpasearch.policy.SearchPolicy;
+import io.github.ggomarighetti.rsqljpasearch.protection.SearchProtectionException;
+import io.github.ggomarighetti.rsqljpasearch.rsql.backend.perplexhub.PerplexhubRsqlEngines;
+import io.github.ggomarighetti.rsqljpasearch.rsql.validation.RsqlFilterValidationException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.data.domain.PageRequest;
+
+public final class RsqlSearchFuzzer {
+    private static final int MAX_INPUT_BYTES = 16_384;
+    private static final SearchCompiler COMPILER =
+            new SearchCompiler(PerplexhubRsqlEngines.defaults(), SearchPolicy.defaults());
+    private static final PageRequest PAGE_REQUEST = PageRequest.of(0, 20);
+    private static final SearchDefinition<Product> DEFINITION = SearchDefinition.builder()
+            .entity(Product.class)
+            .fields(fields -> {
+                fields.add("sku", String.class).filterable();
+                fields.add("name", String.class).filterable();
+                fields.add("stock", Integer.class).filterable();
+            })
+            .paging()
+            .build();
+
+    private RsqlSearchFuzzer() {}
+
+    public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+        String rsql = new String(data.consumeBytes(MAX_INPUT_BYTES), StandardCharsets.UTF_8);
+        try {
+            COMPILER.compile(rsql, null, PAGE_REQUEST, DEFINITION);
+        } catch (RsqlFilterValidationException | SearchProtectionException expected) {
+            // Rejected fuzz input is a normal outcome; other throwables are findings.
+        }
+    }
+
+    static final class Product {
+        private String sku;
+        private String name;
+        private Integer stock;
+
+        public String getSku() {
+            return sku;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Integer getStock() {
+            return stock;
+        }
+    }
+}

--- a/jpa-validation/pom.xml
+++ b/jpa-validation/pom.xml
@@ -9,6 +9,10 @@
   </parent>
   <artifactId>rsql-jpa-search-jpa-validation</artifactId>
   <name>rsql-jpa-search JPA validation</name>
+  <properties>
+    <jacoco.line.minimum>0.94</jacoco.line.minimum>
+    <jacoco.branch.minimum>1.00</jacoco.branch.minimum>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/jpa-validation/pom.xml
+++ b/jpa-validation/pom.xml
@@ -16,6 +16,10 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>rsql-jpa-search-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>rsql-jpa-search-core</artifactId>
     </dependency>
     <dependency>

--- a/perplexhub/pom.xml
+++ b/perplexhub/pom.xml
@@ -9,6 +9,10 @@
   </parent>
   <artifactId>rsql-jpa-search-perplexhub</artifactId>
   <name>rsql-jpa-search Perplexhub adapter</name>
+  <properties>
+    <jacoco.line.minimum>0.62</jacoco.line.minimum>
+    <jacoco.branch.minimum>0.66</jacoco.branch.minimum>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/perplexhub/pom.xml
+++ b/perplexhub/pom.xml
@@ -27,9 +27,31 @@
       <artifactId>rsql-jpa-search-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.github.nstdio</groupId>
+      <artifactId>rsql-parser</artifactId>
+      <version>${rsql.parser.version}</version>
+    </dependency>
+    <dependency>
       <groupId>io.github.perplexhub</groupId>
       <artifactId>rsql-jpa</artifactId>
       <version>${perplexhub.rsql.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.perplexhub</groupId>
+      <artifactId>rsql-common</artifactId>
+      <version>${perplexhub.rsql.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-jpa</artifactId>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,8 @@
     <datasource-proxy.version>1.11.0</datasource-proxy.version>
     <expressly.version>6.0.0</expressly.version>
     <jacoco.version>0.8.15</jacoco.version>
+    <jacoco.line.minimum>0.00</jacoco.line.minimum>
+    <jacoco.branch.minimum>0.00</jacoco.branch.minimum>
     <archunit.version>1.4.2</archunit.version>
     <sonar.maven.plugin.version>5.7.0.6970</sonar.maven.plugin.version>
     <maven.deploy.plugin.version>3.1.4</maven.deploy.plugin.version>
@@ -279,6 +281,32 @@
                     <format>XML</format>
                     <format>HTML</format>
                   </formats>
+                </configuration>
+              </execution>
+              <execution>
+                <id>check</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <rule>
+                      <element>BUNDLE</element>
+                      <limits>
+                        <limit>
+                          <counter>LINE</counter>
+                          <value>COVEREDRATIO</value>
+                          <minimum>${jacoco.line.minimum}</minimum>
+                        </limit>
+                        <limit>
+                          <counter>BRANCH</counter>
+                          <value>COVEREDRATIO</value>
+                          <minimum>${jacoco.branch.minimum}</minimum>
+                        </limit>
+                      </limits>
+                    </rule>
+                  </rules>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/integration/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     <sonar.junit.reportPaths>**/target/surefire-reports,**/target/failsafe-reports</sonar.junit.reportPaths>
+    <!-- ClusterFuzzLite builder images intentionally copy the checked-out repo and use the OSS-Fuzz builder model. -->
+    <sonar.issue.ignore.multicriteria>clusterFuzzLiteRoot,clusterFuzzLiteCopy</sonar.issue.ignore.multicriteria>
+    <sonar.issue.ignore.multicriteria.clusterFuzzLiteRoot.ruleKey>docker:S6471</sonar.issue.ignore.multicriteria.clusterFuzzLiteRoot.ruleKey>
+    <sonar.issue.ignore.multicriteria.clusterFuzzLiteRoot.resourceKey>.github/clusterfuzzlite/Dockerfile</sonar.issue.ignore.multicriteria.clusterFuzzLiteRoot.resourceKey>
+    <sonar.issue.ignore.multicriteria.clusterFuzzLiteCopy.ruleKey>docker:S6470</sonar.issue.ignore.multicriteria.clusterFuzzLiteCopy.ruleKey>
+    <sonar.issue.ignore.multicriteria.clusterFuzzLiteCopy.resourceKey>.github/clusterfuzzlite/Dockerfile</sonar.issue.ignore.multicriteria.clusterFuzzLiteCopy.resourceKey>
   </properties>
 
   <dependencyManagement>

--- a/rsql-spi/pom.xml
+++ b/rsql-spi/pom.xml
@@ -9,6 +9,10 @@
   </parent>
   <artifactId>rsql-jpa-search-rsql-spi</artifactId>
   <name>rsql-jpa-search RSQL SPI</name>
+  <properties>
+    <jacoco.line.minimum>0.89</jacoco.line.minimum>
+    <jacoco.branch.minimum>1.00</jacoco.branch.minimum>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/rsql-spi/src/test/java/io/github/ggomarighetti/rsqljpasearch/rsql/RsqlAstTest.java
+++ b/rsql-spi/src/test/java/io/github/ggomarighetti/rsqljpasearch/rsql/RsqlAstTest.java
@@ -2,6 +2,7 @@ package io.github.ggomarighetti.rsqljpasearch.rsql;
 
 import cz.jirutka.rsql.parser.ast.ComparisonNode;
 import cz.jirutka.rsql.parser.ast.ComparisonOperator;
+import cz.jirutka.rsql.parser.ast.Arity;
 import cz.jirutka.rsql.parser.ast.Node;
 import cz.jirutka.rsql.parser.ast.RSQLVisitor;
 import io.github.ggomarighetti.rsqljpasearch.rsql.metadata.RsqlOperatorRegistry;
@@ -15,10 +16,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class RsqlAstTest {
     @Test
-    @SuppressWarnings("deprecation")
     void rejectsComparisonNodesWithUnregisteredOperators() {
         ComparisonNode node = new ComparisonNode(
-                new ComparisonOperator("=missing=", true),
+                new ComparisonOperator("=missing=", Arity.nary(1)),
                 "email",
                 List.of("person@example.com"));
 

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -9,6 +9,10 @@
   </parent>
   <artifactId>rsql-jpa-search-spring-boot-starter</artifactId>
   <name>rsql-jpa-search Spring Boot starter</name>
+  <properties>
+    <jacoco.line.minimum>0.99</jacoco.line.minimum>
+    <jacoco.branch.minimum>1.00</jacoco.branch.minimum>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -43,6 +43,27 @@
       <artifactId>spring-boot</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.github.perplexhub</groupId>
+      <artifactId>rsql-jpa</artifactId>
+      <version>${perplexhub.rsql.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>


### PR DESCRIPTION
## Summary
- Add cross-platform quality sweep scripts and a consumer compatibility CI job.
- Enforce per-module JaCoCo coverage gates and publish a coverage summary in CI.
- Declare direct module dependencies and remove compiler warning noise from tests.
- Install reactor artifacts before running consumer compatibility checks so invoker projects resolve local SNAPSHOT artifacts in clean CI runners.
- Add ClusterFuzzLite/Jazzer CI using config kept under `.github/clusterfuzzlite` and a fuzz target under `integration/src/fuzz/java` for OpenSSF-visible Jazzer detection.

## Verification
- `./mvnw -B -ntp -nsu -Pcoverage,sbom verify`
- `./mvnw -B -ntp -nsu -Pcoverage,release,sbom,reproducible verify`
- `./mvnw -B -ntp -nsu -pl integration -am -Pconsumer-tests install`
- `./mvnw -B -ntp -nsu -Dmaven.repo.local=target/consumer-check-repo-ci -pl integration -am -Pconsumer-tests install`
- `./mvnw.cmd -B -ntp -nsu -DskipTests validate`
- `docker run ... rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color`
- `docker build -f .github/clusterfuzzlite/Dockerfile -t rsql-jpa-search-cflite:local .`
- `docker run --rm rsql-jpa-search-cflite:local ... "$OUT/RsqlSearchFuzzer" -runs=5`
- PR checks passing, including `ClusterFuzzLite Jazzer (address)` and `SonarCloud Code Analysis`.