### PR TITLE
ci(release): make release-please manually triggered

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,6 @@
 name: Release Please
 
 on:
-  push:
-    branches:
-      - master
   workflow_dispatch:
 
 permissions:
@@ -40,5 +37,6 @@ jobs:
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          target-branch: master
           config-file: .github/release/release-please-config.json
           manifest-file: .github/release/release-please-manifest.json


### PR DESCRIPTION
## Summary
- Make Release Please manual-only by removing the push trigger on master.
- Pin Release Please to prepare release PRs against master when run from the Actions UI.

## Validation
- git diff --check -- .github/workflows/release-please.yml