### PR TITLE
chore: improve OpenSSF release security signals

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,9 +15,7 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Check bootstrap release tag
         id: bootstrap
@@ -32,11 +30,22 @@ jobs:
             echo "::notice::v1.0.0 does not exist yet; release-please is disabled until the bootstrap release is published."
           fi
 
+      - name: Validate release-please token
+        if: steps.bootstrap.outputs.ready == 'true'
+        shell: bash
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          if [[ -z "${RELEASE_PLEASE_TOKEN}" ]]; then
+            echo "::error::Configure RELEASE_PLEASE_TOKEN as a fine-grained PAT or GitHub App token with contents, issues, and pull requests write access."
+            exit 1
+          fi
+
       - name: Release Please
         if: steps.bootstrap.outputs.ready == 'true'
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           target-branch: master
           config-file: .github/release/release-please-config.json
           manifest-file: .github/release/release-please-manifest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,9 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - name: Check bootstrap release tag
         id: bootstrap
@@ -30,22 +32,11 @@ jobs:
             echo "::notice::v1.0.0 does not exist yet; release-please is disabled until the bootstrap release is published."
           fi
 
-      - name: Validate release-please token
-        if: steps.bootstrap.outputs.ready == 'true'
-        shell: bash
-        env:
-          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-        run: |
-          if [[ -z "${RELEASE_PLEASE_TOKEN}" ]]; then
-            echo "::error::Configure RELEASE_PLEASE_TOKEN as a fine-grained PAT or GitHub App token with contents, issues, and pull requests write access."
-            exit 1
-          fi
-
       - name: Release Please
         if: steps.bootstrap.outputs.ready == 'true'
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           target-branch: master
           config-file: .github/release/release-please-config.json
           manifest-file: .github/release/release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,31 @@ jobs:
             | xargs -0 sha256sum \
             > "release-assets/rsql-jpa-search-${version}-SHA256SUMS"
 
+      - name: Sign release checksum manifest
+        if: steps.release.outputs.release == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${{ steps.release.outputs.version }}"
+          install -m 700 -d ~/.gnupg
+          printf '%s' "${JRELEASER_GPG_SECRET_KEY}" | gpg --batch --import
+          key_fingerprint="$(gpg --batch --list-secret-keys --with-colons | awk -F: '/^fpr:/ {print $10; exit}')"
+          if [[ -z "${key_fingerprint}" ]]; then
+            echo "::error::Could not resolve imported GPG key fingerprint."
+            exit 1
+          fi
+
+          gpg --batch --yes --pinentry-mode loopback \
+            --passphrase "${JRELEASER_GPG_PASSPHRASE}" \
+            --armor \
+            --detach-sign \
+            --local-user "${key_fingerprint}" \
+            --output "release-assets/rsql-jpa-search-${version}-SHA256SUMS.asc" \
+            "release-assets/rsql-jpa-search-${version}-SHA256SUMS"
+          gpg --armor --export "${key_fingerprint}" \
+            > "release-assets/rsql-jpa-search-release-public-key.asc"
+
       - name: Attest release provenance
         if: steps.release.outputs.release == 'true' && env.DRY_RUN != 'true'
         id: provenance
@@ -394,6 +419,7 @@ jobs:
             echo "- Existing tag: ${{ steps.release.outputs.tag_exists }}"
             echo "- Parent plus public modules: staged atomically"
             echo "- CycloneDX SBOMs: attached to Maven artifacts"
+            echo "- SHA-256 manifest: signed with the release PGP key"
             echo "- Provenance and SBOM attestations: signed with Sigstore"
             echo "- SHA-256 manifest and buildinfo: attached to the GitHub release"
             echo "- Retired jpa-rsql-search coordinates: not generated"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Javadocs](https://javadoc.io/badge2/io.github.ggomarighetti/rsql-jpa-search-api/javadoc.svg)](https://javadoc.io/doc/io.github.ggomarighetti/rsql-jpa-search-api)
 [![GitHub Release](https://img.shields.io/github/v/release/ggomarighetti/rsql-jpa-search?display_name=tag)](https://github.com/ggomarighetti/rsql-jpa-search/releases)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/ggomarighetti/rsql-jpa-search/badge)](https://scorecard.dev/viewer/?uri=github.com/ggomarighetti/rsql-jpa-search)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13353/badge)](https://www.bestpractices.dev/projects/13353)
 [![Java 17+](https://img.shields.io/badge/Java-17%2B-007396)](https://adoptium.net/)
 [![Spring Boot 4](https://img.shields.io/badge/Spring%20Boot-4.x-6DB33F)](https://spring.io/projects/spring-boot)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
## Summary
- publish the OpenSSF Best Practices badge in the README
- sign the release checksum manifest and export the release public key as part of the release workflow

## Notes
- keeps internal OpenSSF report local and unpublished