### PR TITLE
ci(release): fix SBOM attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,28 @@ jobs:
 
           version="${{ steps.release.outputs.version }}"
           mkdir -p release-assets
-          cp target/bom.json "release-assets/rsql-jpa-search-${version}-aggregate-cyclonedx.json"
+          aggregate_sbom="release-assets/rsql-jpa-search-${version}-aggregate-cyclonedx.json"
+          cp target/bom.json "${aggregate_sbom}"
+          python3 - "${aggregate_sbom}" "${version}" <<'PY'
+          import json
+          import sys
+          import uuid
+
+          path, version = sys.argv[1], sys.argv[2]
+          with open(path, encoding="utf-8") as file:
+              bom = json.load(file)
+
+          if bom.get("bomFormat") == "CycloneDX" and not bom.get("serialNumber"):
+              serial = uuid.uuid5(
+                  uuid.NAMESPACE_URL,
+                  f"https://github.com/ggomarighetti/rsql-jpa-search/releases/tag/v{version}/aggregate-cyclonedx",
+              )
+              bom["serialNumber"] = f"urn:uuid:{serial}"
+
+          with open(path, "w", encoding="utf-8") as file:
+              json.dump(bom, file, indent=2)
+              file.write("\n")
+          PY
           cp "target/rsql-jpa-search-parent-${version}.buildinfo" \
             "release-assets/rsql-jpa-search-${version}.buildinfo"
 


### PR DESCRIPTION
### Resume

Fix the release workflow failure in the SBOM attestation step for `2.0.0`.

The failed release run passed build, staging, artifact inspection, checksum signing, and provenance attestation, then failed at `Attest aggregate SBOM` with:

```text
Unsupported SBOM format. Must be valid SPDX or CycloneDX JSON.
```

`actions/attest` detects CycloneDX by requiring `bomFormat`, `specVersion`, and `serialNumber`. Our Maven-generated aggregate SBOM intentionally omits `serialNumber` because `includeBomSerialNumber=false` keeps Maven SBOM artifacts reproducible.

This patch keeps Maven SBOM generation unchanged and adds a deterministic UUIDv5 `serialNumber` only to the copied release asset used for SBOM attestation.

### Evidence

- Verified `.github/workflows/release.yml` parses as YAML.
- Tested the SBOM copy transformation locally against `target/bom.json`; it preserves `bomFormat: CycloneDX` and `specVersion: 1.6`, and adds `serialNumber: urn:uuid:8036d212-289d-502c-9e80-0d11b4846b36` for `2.0.0`.
- Confirmed the failed release run stopped before tag creation and package publication.

### Reference

Failed run: https://github.com/ggomarighetti/rsql-jpa-search/actions/runs/28132545715