### PR TITLE
fix(release): add module pom metadata

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -9,6 +9,8 @@
   </parent>
   <artifactId>rsql-jpa-search-api</artifactId>
   <name>rsql-jpa-search API</name>
+  <description>Public API contracts and Spring Data JPA search abstractions for rsql-jpa-search.</description>
+  <url>https://github.com/ggomarighetti/rsql-jpa-search/tree/master/api</url>
   <properties>
     <jacoco.line.minimum>0.95</jacoco.line.minimum>
     <jacoco.branch.minimum>0.85</jacoco.branch.minimum>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -9,6 +9,8 @@
   </parent>
   <artifactId>rsql-jpa-search-core</artifactId>
   <name>rsql-jpa-search core</name>
+  <description>Core RSQL-to-Spring Data JPA query implementation for rsql-jpa-search.</description>
+  <url>https://github.com/ggomarighetti/rsql-jpa-search/tree/master/core</url>
   <properties>
     <jacoco.line.minimum>0.97</jacoco.line.minimum>
     <jacoco.branch.minimum>0.98</jacoco.branch.minimum>

--- a/jpa-validation/pom.xml
+++ b/jpa-validation/pom.xml
@@ -9,6 +9,8 @@
   </parent>
   <artifactId>rsql-jpa-search-jpa-validation</artifactId>
   <name>rsql-jpa-search JPA validation</name>
+  <description>JPA metamodel validation support for rsql-jpa-search criteria and paths.</description>
+  <url>https://github.com/ggomarighetti/rsql-jpa-search/tree/master/jpa-validation</url>
   <properties>
     <jacoco.line.minimum>0.94</jacoco.line.minimum>
     <jacoco.branch.minimum>1.00</jacoco.branch.minimum>

--- a/perplexhub/pom.xml
+++ b/perplexhub/pom.xml
@@ -9,6 +9,8 @@
   </parent>
   <artifactId>rsql-jpa-search-perplexhub</artifactId>
   <name>rsql-jpa-search Perplexhub adapter</name>
+  <description>Adapter module that bridges rsql-jpa-search with the Perplexhub RSQL JPA model.</description>
+  <url>https://github.com/ggomarighetti/rsql-jpa-search/tree/master/perplexhub</url>
   <properties>
     <jacoco.line.minimum>0.62</jacoco.line.minimum>
     <jacoco.branch.minimum>0.66</jacoco.branch.minimum>

--- a/rsql-spi/pom.xml
+++ b/rsql-spi/pom.xml
@@ -9,6 +9,8 @@
   </parent>
   <artifactId>rsql-jpa-search-rsql-spi</artifactId>
   <name>rsql-jpa-search RSQL SPI</name>
+  <description>RSQL parser integration SPI for converting RSQL expressions into rsql-jpa-search criteria.</description>
+  <url>https://github.com/ggomarighetti/rsql-jpa-search/tree/master/rsql-spi</url>
   <properties>
     <jacoco.line.minimum>0.89</jacoco.line.minimum>
     <jacoco.branch.minimum>1.00</jacoco.branch.minimum>

--- a/spring-boot-starter/pom.xml
+++ b/spring-boot-starter/pom.xml
@@ -9,6 +9,8 @@
   </parent>
   <artifactId>rsql-jpa-search-spring-boot-starter</artifactId>
   <name>rsql-jpa-search Spring Boot starter</name>
+  <description>Spring Boot auto-configuration starter for rsql-jpa-search.</description>
+  <url>https://github.com/ggomarighetti/rsql-jpa-search/tree/master/spring-boot-starter</url>
   <properties>
     <jacoco.line.minimum>0.99</jacoco.line.minimum>
     <jacoco.branch.minimum>1.00</jacoco.branch.minimum>


### PR DESCRIPTION
## Summary
- add explicit `<description>` and `<url>` metadata to every Maven Central-published module POM
- keep parent metadata unchanged while avoiding PomChecker's per-module inheritance fallback errors

## Release failure
The second 2.0.0 release retry passed the SBOM attestation fix, then failed in `JReleaser dry-run` because Maven Central PomChecker rejected the staged module POMs:

- `rsql-jpa-search-api`
- `rsql-jpa-search-rsql-spi`
- `rsql-jpa-search-core`
- `rsql-jpa-search-jpa-validation`
- `rsql-jpa-search-perplexhub`
- `rsql-jpa-search-spring-boot-starter`

Each module inherited the parent description and URL, but PomChecker requires those fields to be explicit in the published module POM.

## Validation
- `./mvnw.cmd -B -ntp -nsu "-Ppublication,sbom,reproducible" -DskipTests deploy`
- inspected `target/staging-deploy` and confirmed all six published module POMs now include explicit `description` and `url`
- local JReleaser dry-run reached POM verification; PomChecker was skipped on Windows and the run then stopped at signing because local GPG values were dummy