### PR TITLE
ci: let Dependabot manage CI tool images

### DIFF
--- a/.github/clusterfuzzlite/Dockerfile
+++ b/.github/clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:e3ac22ef17541ca88d404971801c4d8191860f8bf5429f59ebd229a4e6c42cd4
+FROM gcr.io/oss-fuzz-base/base-builder-jvm:v1@sha256:e3ac22ef17541ca88d404971801c4d8191860f8bf5429f59ebd229a4e6c42cd4
 
 COPY . $SRC/rsql-jpa-search
 WORKDIR $SRC/rsql-jpa-search

--- a/.github/clusterfuzzlite/Dockerfile
+++ b/.github/clusterfuzzlite/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/oss-fuzz-base/base-builder-jvm:v1@sha256:e3ac22ef17541ca88d404971801c4d8191860f8bf5429f59ebd229a4e6c42cd4
+FROM gcr.io/oss-fuzz-base/base-builder-jvm@sha256:e3ac22ef17541ca88d404971801c4d8191860f8bf5429f59ebd229a4e6c42cd4
 
 COPY . $SRC/rsql-jpa-search
 WORKDIR $SRC/rsql-jpa-search

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,44 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+
+  - package-ecosystem: "docker-compose"
+    directory: "/.github/tools"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Argentina/Cordoba"
+
+    labels:
+      - "dependencies"
+      - "docker"
+
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+    groups:
+      ci-images:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directory: "/.github/clusterfuzzlite"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Argentina/Cordoba"
+
+    labels:
+      - "dependencies"
+      - "docker"
+
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/scripts/verify-quality.ps1
+++ b/.github/scripts/verify-quality.ps1
@@ -16,22 +16,17 @@ try {
     }
 
     & .\mvnw.cmd -B -ntp -nsu -pl integration -am "-Pconsumer-tests" install
-    & .\mvnw.cmd -B -ntp -nsu -DskipTests org.apache.maven.plugins:maven-dependency-plugin:3.9.0:analyze
+    & .\mvnw.cmd -B -ntp -nsu -DskipTests dependency:analyze
 
     if (-not $SkipDockerChecks) {
         if (Get-Command docker -ErrorAction SilentlyContinue) {
-            docker run --rm `
-                --volume "$($root.Path):/repo" `
-                --workdir /repo `
-                rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 `
-                -color
+            docker compose --file .github/tools/compose.yml run --rm actionlint -color
 
             if (Test-Path (Join-Path $root "target\bom.json")) {
-                docker run --rm `
-                    --volume "$($root.Path):/src" `
-                    ghcr.io/google/osv-scanner@sha256:5116601dedc01c1c580eb92371883ec052fc4c13c3fbc109d621a63ac416d475 `
+                docker compose --file .github/tools/compose.yml run --rm `
+                    osv-scanner `
                     scan `
-                    -L /src/target/bom.json
+                    -L /workspace/target/bom.json
             } else {
                 Write-Warning "Skipping OSV scan because target\bom.json was not generated."
             }

--- a/.github/scripts/verify-quality.sh
+++ b/.github/scripts/verify-quality.sh
@@ -29,22 +29,17 @@ if [[ "${skip_release}" != "true" ]]; then
 fi
 
 ./mvnw -B -ntp -nsu -pl integration -am -Pconsumer-tests install
-./mvnw -B -ntp -nsu -DskipTests org.apache.maven.plugins:maven-dependency-plugin:3.9.0:analyze
+./mvnw -B -ntp -nsu -DskipTests dependency:analyze
 
 if [[ "${skip_docker}" != "true" ]]; then
   if command -v docker >/dev/null 2>&1; then
-    docker run --rm \
-      --volume "${root}:/repo" \
-      --workdir /repo \
-      rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
-      -color
+    docker compose --file .github/tools/compose.yml run --rm actionlint -color
 
     if [[ -f target/bom.json ]]; then
-      docker run --rm \
-        --volume "${root}:/src" \
-        ghcr.io/google/osv-scanner@sha256:5116601dedc01c1c580eb92371883ec052fc4c13c3fbc109d621a63ac416d475 \
+      docker compose --file .github/tools/compose.yml run --rm \
+        osv-scanner \
         scan \
-        -L /src/target/bom.json
+        -L /workspace/target/bom.json
     else
       echo "Skipping OSV scan because target/bom.json was not generated." >&2
     fi

--- a/.github/tools/compose.yml
+++ b/.github/tools/compose.yml
@@ -1,0 +1,24 @@
+services:
+  cue:
+    image: cuelang/cue:0.16.1@sha256:02a15644a421cbbb91a6137d980b061b1f93ccf3504c8efcd091ec8060e6a406
+    working_dir: /workspace
+    volumes:
+      - ../..:/workspace
+
+  actionlint:
+    image: rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667
+    working_dir: /workspace
+    volumes:
+      - ../..:/workspace
+
+  osv-scanner:
+    image: ghcr.io/google/osv-scanner:v2.4.0@sha256:5116601dedc01c1c580eb92371883ec052fc4c13c3fbc109d621a63ac416d475
+    working_dir: /workspace
+    volumes:
+      - ../..:/workspace
+
+  clusterfuzzlite-build-fuzzers:
+    image: gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:v1@sha256:79a88907cce4e93d48b5c5ca97a833686636d07d91b7d82abf9e39ebd96b0b42
+
+  clusterfuzzlite-run-fuzzers:
+    image: gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers:v1@sha256:0c3180277e25dd8637a55270f666fbdac038be38fa736080c95ade75a84e8637

--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -45,11 +45,10 @@ jobs:
 
       - name: Build fuzzers
         env:
-          BUILD_FUZZERS_IMAGE: gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers@sha256:79a88907cce4e93d48b5c5ca97a833686636d07d91b7d82abf9e39ebd96b0b42
           CFL_CONTAINER: cflite-build-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.sanitizer }}
           SANITIZER: ${{ matrix.sanitizer }}
         run: |
-          docker run --rm --name "$CFL_CONTAINER" \
+          docker compose --file .github/tools/compose.yml run --rm --name "$CFL_CONTAINER" \
             --volume /var/run/docker.sock:/var/run/docker.sock \
             --volume "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
             --workdir "${GITHUB_WORKSPACE}" \
@@ -62,17 +61,16 @@ jobs:
             --env "KEEP_UNAFFECTED_FUZZ_TARGETS=true" \
             --env "LOW_DISK_SPACE=true" \
             --env "NO_CLUSTERFUZZ_DEPLOYMENT=true" \
-            "$BUILD_FUZZERS_IMAGE"
+            clusterfuzzlite-build-fuzzers
 
       - name: Run fuzzers
         env:
           CFL_CONTAINER: cflite-run-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.sanitizer }}
           FUZZ_SECONDS: ${{ github.event_name == 'schedule' && '300' || '60' }}
           MODE: ${{ github.event_name == 'pull_request' && 'code-change' || 'batch' }}
-          RUN_FUZZERS_IMAGE: gcr.io/oss-fuzz-base/clusterfuzzlite-run-fuzzers@sha256:0c3180277e25dd8637a55270f666fbdac038be38fa736080c95ade75a84e8637
           SANITIZER: ${{ matrix.sanitizer }}
         run: |
-          docker run --rm --name "$CFL_CONTAINER" \
+          docker compose --file .github/tools/compose.yml run --rm --name "$CFL_CONTAINER" \
             --volume /var/run/docker.sock:/var/run/docker.sock \
             --volume "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \
             --workdir "${GITHUB_WORKSPACE}" \
@@ -87,4 +85,4 @@ jobs:
             --env "PARALLEL_FUZZING=true" \
             --env "LOW_DISK_SPACE=true" \
             --env "NO_CLUSTERFUZZ_DEPLOYMENT=true" \
-            "$RUN_FUZZERS_IMAGE"
+            clusterfuzzlite-run-fuzzers

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -61,6 +61,11 @@ jobs:
       security-events: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
       - name: Download aggregate SBOM
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -70,13 +75,12 @@ jobs:
       - name: Scan SBOM
         shell: bash
         run: |
-          docker run --rm \
-            --volume "${PWD}:/src" \
-            ghcr.io/google/osv-scanner@sha256:5116601dedc01c1c580eb92371883ec052fc4c13c3fbc109d621a63ac416d475 \
+          docker compose --file .github/tools/compose.yml run --rm \
+            osv-scanner \
             scan \
-            -L /src/bom.json \
+            -L /workspace/bom.json \
             --format sarif \
-            --output-file /src/osv-results.sarif
+            --output-file /workspace/osv-results.sarif
 
       - name: Upload OSV results artifact
         if: ${{ always() }}

--- a/.github/workflows/security-metadata.yml
+++ b/.github/workflows/security-metadata.yml
@@ -26,20 +26,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up CUE
-        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
-
       - name: Validate document
         shell: bash
         run: |
           set -euo pipefail
-          schema="${RUNNER_TEMP}/security-insights-schema.cue"
+          schema="target/security-insights-schema.cue"
+          mkdir -p target
           curl --fail --silent --show-error --location \
             --proto '=https' \
             --proto-redir '=https' \
             "https://raw.githubusercontent.com/ossf/security-insights/701ac2a02ef17fc8b316f5df685428773c51372a/spec/schema.cue" \
             --output "${schema}"
-          cue vet -d '#SecurityInsights' "${schema}" SECURITY-INSIGHTS.yml
+          docker compose --file .github/tools/compose.yml run --rm \
+            cue vet -d '#SecurityInsights' "${schema}" SECURITY-INSIGHTS.yml
 
   actionlint:
     name: Validate GitHub Actions
@@ -57,8 +56,4 @@ jobs:
       - name: Run actionlint
         shell: bash
         run: |
-          docker run --rm \
-            --volume "${PWD}:/repo" \
-            --workdir /repo \
-            rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
-            -color
+          docker compose --file .github/tools/compose.yml run --rm actionlint -color

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,10 @@
           <version>3.15.0</version>
         </plugin>
         <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.9.0</version>
+        </plugin>
+        <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.5.6</version>
         </plugin>


### PR DESCRIPTION
## Summary
- replace the floating `setup-cue` install with a digest-pinned CUE container
- centralize CUE, Actionlint, OSV Scanner, and ClusterFuzzLite runtime images in a Docker Compose manifest
- enable Dependabot updates for Docker Compose and the ClusterFuzzLite Dockerfile
- move the Maven dependency plugin version from quality scripts into `pom.xml`

## Why
The Security Metadata check resolved `latest` to CUE v0.17.0 before its release assets existed. Keeping tool images in supported manifests preserves immutable digests while allowing Dependabot to propose tested version updates.

## Validation
- `.github/scripts/verify-quality.ps1 -SkipReleaseProfile`
- CUE validation of `SECURITY-INSIGHTS.yml`
- Actionlint
- OSV Scanner startup and SBOM scan
- `docker compose config`
- `git diff --check`