### PR TITLE
ci(deps): bump github/codeql-action from 4.36.2 to 4.36.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,15 @@ updates:
       prefix: "ci"
       include: "scope"
 
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "docker-compose"
     directory: "/.github/tools"
     schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
           cache: maven
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -62,6 +62,6 @@ jobs:
         run: ./mvnw -B -ntp -nsu -DskipTests package
 
       - name: Analyze
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           category: /language:${{ matrix.language }}


### PR DESCRIPTION
### Resume
- Bumps `github/codeql-action/init` and `github/codeql-action/analyze` from 4.36.2 to 4.36.3 in one atomic workflow update.
- Adds a Dependabot `github-actions` group for `github/codeql-action/*` so future CodeQL sub-action updates are proposed together.
- Keeps SHA pinning for GitHub Actions to preserve the repository supply-chain hardening posture.

### Evidence
- `git diff --check` passed.
- `.github/dependabot.yml` and `.github/workflows/codeql.yml` parsed successfully as YAML with PyYAML.
- The commit includes DCO sign-off: `Signed-off-by: Guillermo Orue Marighetti <ggomarighetti@gmail.com>`.
- This change addresses the failing CodeQL mismatch observed in #54 and #55, where `init` and `analyze` were updated separately.

### Reference
- Supersedes #54 and #55 once this combined PR is green and merged.
- Builds on #53, which already updated `github/codeql-action/upload-sarif` to 4.36.3.
- Dependabot groups reference: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
- CodeQL workflow configuration reference: https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options