### PR TITLE
fix(deps): update Logback and synchronize CodeQL actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
       include: "scope"
 
     groups:
+      logback:
+        patterns:
+          - "ch.qos.logback:*"
       maven-dependencies:
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,12 +50,11 @@ updates:
 
     groups:
       codeql-action:
+        # SHA-pinned actions have no semantic version for Dependabot's
+        # update-types filter, so omitting it keeps every CodeQL action grouped.
         patterns:
+          - "github/codeql-action"
           - "github/codeql-action/*"
-        update-types:
-          - "major"
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "docker-compose"
     directory: "/.github/tools"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
           cache: maven
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -62,6 +62,6 @@ jobs:
         run: ./mvnw -B -ntp -nsu -DskipTests package
 
       - name: Analyze
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -93,6 +93,6 @@ jobs:
 
       - name: Upload OSV results to code scanning
         if: ${{ always() }}
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: osv-results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -50,6 +50,6 @@ jobs:
 
       - name: Upload Scorecard results to code scanning
         if: ${{ always() }}
-        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           sarif_file: scorecard-results.sarif

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <project.build.outputTimestamp>2026-06-15T17:29:14Z</project.build.outputTimestamp>
     <maven.compiler.release>17</maven.compiler.release>
     <spring.boot.version>4.1.0</spring.boot.version>
+    <logback.version>1.5.38</logback.version>
     <rsql.parser.version>2.4.0</rsql.parser.version>
     <perplexhub.rsql.version>7.0.2</perplexhub.rsql.version>
     <datasource-proxy.version>1.11.0</datasource-proxy.version>
@@ -87,6 +88,17 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Keep Logback explicit so Dependabot can update it independently of the Spring Boot BOM. -->
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>


### PR DESCRIPTION
### Resume

- Force Logback Core and Classic to 1.5.38 through explicit dependency management, overriding the Spring Boot BOM version affected by CVE-2026-10532.
- Add a dedicated Dependabot group for all `ch.qos.logback` artifacts so both modules advance together.
- Align CodeQL `init`, `analyze`, and `upload-sarif` on the verified `v4.37.0` commit SHA.
- Fix the CodeQL Dependabot group for SHA-pinned actions by omitting the semantic `update-types` filter that caused each subaction to be updated in a separate PR.

### Evidence

- `./mvnw.cmd -B -ntp -nsu -DskipITs verify` — build successful across all eight modules.
- `./mvnw.cmd -B -ntp -nsu -DskipTests -Psbom package` — SBOM generated with Logback Core and Classic 1.5.38.
- Maven Central SHA-512 checksums matched the downloaded Logback 1.5.38 JARs.
- OSV reported no known vulnerabilities for Logback Core or Classic 1.5.38.
- All four CodeQL references resolve to the same verified commit: `99df26d4f13ea111d4ec1a7dddef6063f76b97e9`.
- YAML parsing, `git diff --check`, and Actionlint 1.7.12 completed successfully.

### Reference

- [CVE-2026-10532 / GHSA-jhq6-gfmj-v8fx](https://github.com/qos-ch/logback/security/advisories/GHSA-jhq6-gfmj-v8fx)
- Unblocks the shared security check failure affecting Dependabot PRs #57 through #61.
