### PR TITLE
ci(dependabot): require seven-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
       time: "09:00"
       timezone: "America/Argentina/Cordoba"
 
+    cooldown:
+      default-days: 7
+
     open-pull-requests-limit: 5
 
     labels:
@@ -40,6 +43,9 @@ updates:
       time: "09:00"
       timezone: "America/Argentina/Cordoba"
 
+    cooldown:
+      default-days: 7
+
     labels:
       - "dependencies"
       - "github-actions"
@@ -63,6 +69,9 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Argentina/Cordoba"
+
+    cooldown:
+      default-days: 7
 
     labels:
       - "dependencies"
@@ -88,6 +97,9 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Argentina/Cordoba"
+
+    cooldown:
+      default-days: 7
 
     labels:
       - "dependencies"


### PR DESCRIPTION
Applies Dependabot's native 7-day cooldown to Maven, GitHub Actions, Docker Compose, and Docker version updates. Security updates remain immediate because GitHub intentionally excludes them from cooldown. Validated the YAML, all four update entries, and git diff --check.